### PR TITLE
Add xpu_clean() on errors, instead of only on happy path

### DIFF
--- a/src/simulator.cc
+++ b/src/simulator.cc
@@ -58,6 +58,7 @@ int main(int argc, char **argv)
   if (!qasm_file)
   {
     std::cerr << "[x] Error: Could not open " << file_path << std::endl;
+    xpu::clean();
     return -1;
   }
 
@@ -73,6 +74,7 @@ int main(int argc, char **argv)
   {
     std::cerr << "Error while parsing file " << file_path << ": " << std::endl;
     std::cerr << e.what() << std::endl;
+    xpu::clean();
     return -1;
   }
 
@@ -97,6 +99,7 @@ int main(int argc, char **argv)
     catch (std::string type)
     {
       std::cerr << "[x] Encountered unsuported gate: " << type << std::endl;
+      xpu::clean();
       return -1;
     }
   }


### PR DESCRIPTION
This fixes issue #20 - except on syntax errors. I believe that is because the older libqasm version used currently in qx doesn't throw an exception but exit()'s directly. Should be fixed by updating libqasm (@kel85uk is currently working on adding libqasm as a submodule to qx, issue #19).