### PR TITLE
initial fix for integer overflow in qubit register initalization (#18)

### DIFF
--- a/src/core/linalg.h
+++ b/src/core/linalg.h
@@ -50,7 +50,7 @@ namespace qx
 // 	 typedef ublas::matrix<complex_t>  cmatrix_t;
 // 	 typedef ublas::identity_matrix<complex_t> cidentity_t;
 // #else
-	 typedef std::vector<complex_t,xpu::aligned_memory_allocator<complex_t,32> >  cvector_t;
+	 typedef std::vector<complex_t,xpu::aligned_memory_allocator<complex_t,64> >  cvector_t;
 	 // typedef xpu::vector<complex_t,16>  cvector_t;
 	 // typedef qx::linalg::matrix<complex_t>  cmatrix_t;
 	 typedef qx::linalg::tiny_matrix<complex_t,2>  cmatrix_t;

--- a/src/core/register.cc
+++ b/src/core/register.cc
@@ -1,3 +1,5 @@
+#include <exception>
+
 /**
  * set_binary
  */
@@ -76,17 +78,23 @@ std::string  qx::qu_register::to_binary_string(uint32_t state, uint32_t nq)
  */
 // qx::qu_register::qu_register(uint32_t n_qubits) : data(1 << n_qubits), binary(n_qubits), n_qubits(n_qubits), rgenerator(xpu::timer().current()*10e5), udistribution(.0,1)
 //qx::qu_register::qu_register(uint32_t n_qubits) : data(1 << n_qubits), measurement_prediction(n_qubits), measurement_register(n_qubits), n_qubits(n_qubits), rgenerator(xpu::timer().current()*10e5), udistribution(.0,1)
-qx::qu_register::qu_register(uint32_t n_qubits) : data(1 << n_qubits), aux(1 << n_qubits), measurement_prediction(n_qubits), measurement_register(n_qubits), n_qubits(n_qubits), rgenerator(xpu::timer().current()*10e5), udistribution(.0,1), measurement_averaging_enabled(true), measurement_averaging(n_qubits)
+qx::qu_register::qu_register(uint32_t n_qubits) : data(1ULL << n_qubits), aux(1ULL << n_qubits), measurement_prediction(n_qubits), measurement_register(n_qubits), n_qubits(n_qubits), rgenerator(xpu::timer().current()*10e5), udistribution(.0,1), measurement_averaging_enabled(true), measurement_averaging(n_qubits)
 {
+   if(n_qubits>63) {
+	   throw std::invalid_argument("hard limit of 63 qubits exceeded");
+   }
+
    data[0] = complex_t(1,0);
-   for (uint32_t i=1; i<(1 << n_qubits); ++i)
+   for (uint64_t i=1; i<(1ULL << n_qubits); ++i) {
       data[i] = 0;
+   }
+
    for (uint32_t i=0; i<n_qubits; i++)
    {
       measurement_prediction[i] = __state_0__;
       measurement_register[i]   = 0;
    }
-      //binary[i] = __state_0__;
+
    for (size_t i=0; i<measurement_averaging.size(); ++i)
    {
       measurement_averaging[i].ground_states = 0;

--- a/src/simulator.cc
+++ b/src/simulator.cc
@@ -81,8 +81,19 @@ int main(int argc, char **argv)
   std::vector<qx::circuit*> circuits;
   uint32_t qubits = ast.numQubits();
   println("[+] creating quantum register of " << qubits << " qubits... ");
-  qx::qu_register reg(qubits);
-  
+  qx::qu_register *reg = NULL;
+
+  try {
+	   reg = new qx::qu_register(qubits);
+  } catch(std::bad_alloc& exception) {
+	   std::cerr << "[x] not enough memory, aborting" << std::endl;
+	   xpu::clean();
+	   return -1;
+  } catch(std::exception& exception) {
+	   std::cerr << "[x] unexpected exception (" << exception.what() << "), aborting" << std::endl;
+	   xpu::clean();
+	   return -1;
+  }
 
   // Convert libqasm ast to qx internal representation
   qx::QxRepresentation qxr = qx::QxRepresentation(qubits);
@@ -138,7 +149,7 @@ int main(int argc, char **argv)
   }
  
   for (uint32_t i=0; i<circuits.size(); i++)
-     circuits[i]->execute(reg);
+     circuits[i]->execute(*reg);
  
   xpu::clean();
 

--- a/src/simulator_old.cc
+++ b/src/simulator_old.cc
@@ -59,10 +59,20 @@ int main(int argc, char **argv)
    qcp.parse();
    //qcp.dump();
 
+   qx::qu_register *reg = NULL;
 
    println("[+] creating quantum register of " << qcp.qubits() << " qubits... ");
-   qx::qu_register reg(qcp.qubits());
-
+   try {
+	   reg = new qx::qu_register(qcp.qubits());
+   } catch(std::bad_alloc& exception) {
+	   println("[!] not enough memory, aborting");
+	   xpu::clean();
+	   return -1;
+   } catch(std::exception& exception) {
+	   println("[!] unexpected exception (" << exception.what() << "), aborting");
+	   xpu::clean();
+	   return -1;
+   }
 
    qx::circuits_t circuits;
 
@@ -106,8 +116,10 @@ int main(int argc, char **argv)
   
    // qcp.execute(reg);
    for (uint32_t i=0; i<circuits.size(); i++)
-      circuits[i]->execute(reg);
+      circuits[i]->execute(*reg);
   
+   xpu::clean();
+
    return 0;
 }
 

--- a/src/xpu-0.1.5/xpu/aligned_memory_allocator.h
+++ b/src/xpu-0.1.5/xpu/aligned_memory_allocator.h
@@ -3,6 +3,7 @@
 
 #include <cstdlib>
 #include <mm_malloc.h>
+#include <new>
 
 namespace xpu
 {
@@ -37,8 +38,11 @@ namespace xpu
 	    }
 
 	    inline pointer allocate (size_type n) {
-	       // return (pointer)_aligned_malloc(n*sizeof(value_type), N);
-	       return (pointer)_mm_malloc(n*sizeof(value_type), N);
+	       pointer rv = (pointer)_mm_malloc(n*sizeof(value_type), N);
+	       if(NULL==rv) {
+             throw std::bad_alloc();
+	       }
+	       return rv;
 	    }
 
 	    inline void deallocate (pointer p, size_type) {


### PR DESCRIPTION
This is an attempt to fix #18, but i doubt it fixes it entirely. At the very least it will report an 'out of memory' when not the requirered memory can not be allocated or when the number of qubits requested would lead to an integeger overflow. Someone should carefully check that all relevant data structures and indexing variables are now all of sufficient size (uint64_t for indices).

I've considered doing the right thing, and using std::size_t instead, but went for uint64_t instead because that is more explicit.