### PR TITLE
generic_worker.h: remove duplicate unlock (fix #35)

### DIFF
--- a/src/xpu-0.1.5/xpu/core/generic_worker.h
+++ b/src/xpu-0.1.5/xpu/core/generic_worker.h
@@ -178,8 +178,6 @@ namespace xpu
 				 }
 				 if (!t_control->active())
 				 {
-				    t_control->unlock();
-				    //println("[+] generic worker left : work queue not active anymore (tid:" << pthread_self() << ")");
 				    break;
 				 }
 				 try 


### PR DESCRIPTION
Unlocking an unlocked mutex results in undefined behaviour according
to the man page. Remove the logic error that would result in calling
unlock twice in a row on the same mutex. This solves issue #35.

I'm not too thrilled about the try/catch block in the run() method
either, but i'll create a ticket for that. In general, the multi-
processing code should be checked for logic errors like this.