### PR TITLE
Update range.h

### DIFF
--- a/src/xpu-0.1.5/xpu/range.h
+++ b/src/xpu-0.1.5/xpu/range.h
@@ -86,7 +86,7 @@ namespace xpu
 #ifdef  __xpu_use_spinlock__
 	    m = new spinlock(); 
 #else // use mutex
-	    m = new mutex(); 
+	    m = new xpu::core::os::mutex(); 
 #endif
 #endif
 	    if ((max-min) >= core::workers_count) 


### PR DESCRIPTION
The class `mutex` from the nested namespace `xpu::core::os` can lead to lookup ambiguity with the class `mutex` from the namespace `std::__1::mutex` if QX is used as API within a C++ code that indirectly includes the `mutex` class from the standard library. As example, this happens of QX and OpenQL are included as API in the same C++ code.