### PR TITLE
Update lockable_factory.cc

### DIFF
--- a/src/xpu-0.1.5/xpu/core/lockable_factory.cc
+++ b/src/xpu-0.1.5/xpu/core/lockable_factory.cc
@@ -54,7 +54,7 @@
        #ifdef __XPU_USE_SPINLOCK__
          lockable * l = new spinlock();
        #else
-         lockable * l = new mutex();
+         lockable * l = new xpu::core::os::mutex();
        #endif
        m_shared[p] = l;
 


### PR DESCRIPTION
The class `mutex` from the nested namespace `xpu::core::os` can lead to lookup ambiguity with the class `mutex` from the namespace `std::__1::mutex` if QX is used as API within a C++ code that indirectly includes the `mutex` class from the standard library. As example, this happens of QX and OpenQL are included as API in the same C++ code.