### PR TITLE
Issue 64: classical not with SGMQ fix

### DIFF
--- a/src/libqasm_interface.h
+++ b/src/libqasm_interface.h
@@ -32,12 +32,14 @@
 
 #define __ret_bin_gate(__g) \
 {\
+   if (!pg && (bv.size() > 1))\
+      pg = new qx::parallel_gates();\
    if (!pg)\
-         return new __g(bid(operation));\
+      return new __g(bid(operation));\
    else\
    {\
-         for (auto b : bv)\
-            pg->add(new __g(b));\
+      for (auto b : bv)\
+         pg->add(new __g(b));\
       return pg;\
    }\
 }\
@@ -111,7 +113,7 @@ qx::gate *gateLookup(compiler::Operation &operation)
 
    if (bv.size())
       bc = true;
-   if (qv.size() > 1) 
+   if (qv.size() > 1)
       pg = new qx::parallel_gates();
 
    //if (bc) { std::cout << operation.getControlBits().printMembers(); }
@@ -151,7 +153,7 @@ qx::gate *gateLookup(compiler::Operation &operation)
    if (type == "i")
       __ret_gate_1(qx::identity)
    if (type == "x")
-	  __ret_gate_1(qx::pauli_x)
+      __ret_gate_1(qx::pauli_x)
    if (type == "y")
       __ret_gate_1(qx::pauli_y)
    if (type == "z")

--- a/tests/circuits/classical_not.qc
+++ b/tests/circuits/classical_not.qc
@@ -1,0 +1,57 @@
+version 1.0
+
+# file   : classical_not.qc
+# author : Fer Grooteman
+# brief  : test classical not
+
+qubits 4
+
+.mapping
+  map b[0:3], bitcontroller
+
+.init
+  x q[0:3]
+  measure q[0:3]
+  display
+
+.not_single_bit
+  not b[0]
+  display
+  not b[1]
+  display
+  not b[2]
+  display
+  not b[3]
+  display
+  not b[3]
+  display
+  not b[2]
+  display
+  not b[1]
+  display
+  not b[0]
+  display
+
+.not_two_bits
+  not b[0:1]
+  display
+  not b[2:3]
+  display
+  not b[2,3]
+  display
+  not b[0,1]
+  display
+
+.not_four_bits
+  not b[0:3]
+  display
+  not b[0,1,2,3]
+  display
+
+.not_four_mapped_bits
+  not bitcontroller
+  display
+  not bitcontroller
+  display
+
+


### PR DESCRIPTION
* Made a fix for issue #64 : in libqasm_interface.h the else part of macro __ret_bin_gate was never executed because pg is always NULL in case of operations as:
`not b[0]`
and
`not b[0:4]`
In the latter case, also the if part was executed resulting in negating only the first bit of the involved classical bits (see method bid).
For a not-operation with more than one bit (bv.size() > 1) parallel gates should be used.
I solved this in the macro instead of in the method gate_Lookup because the bug only applied to the classical not operation.
* Added tests to a new file "classical_not.gc" in tests/circuits. Without the fix only the single bit not-operations are working correctly. With the multiple bit not-operations only the first bit in negated.
* Did some re-formatting of some code lines and changed a tab into spaces.