### PR TITLE
Release version 0.5.0

### DIFF
--- a/.github/workflows/assets.yml
+++ b/.github/workflows/assets.yml
@@ -19,6 +19,7 @@ jobs:
         - '3.7'
         - '3.8'
         - '3.9'
+        - '3.10'
     steps:
     - uses: actions/checkout@v2
       with:
@@ -128,6 +129,7 @@ jobs:
         - '3.7'
         - '3.8'
         - '3.9'
+        - '3.10'
     steps:
     - uses: actions/checkout@v2
       with:

--- a/.github/workflows/assets.yml
+++ b/.github/workflows/assets.yml
@@ -145,7 +145,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        choco install winflexbison3 --version 2.5.18.20190508
+        choco install winflexbison3 --version 2.5.24.20210105
     - name: Enable CPU compatibility mode
       run: echo "QX_CPU_COMPATIBILITY_MODE=ON" >> $GITHUB_ENV
     - name: Build wheel

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,6 +60,7 @@ jobs:
         - '3.7'
         - '3.8'
         - '3.9'
+        - '3.10'
     steps:
     - uses: actions/checkout@v2
       with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [ 0.5.0 ] - [ 2022-11-15 ]
+### Added
+- "-j <filename>" CLI option to output JSON to a file
+- Possible to use the simulator without OpenMP.
+
+### Changed
+- Measure_all gate added; does no longer measure each qubit separately.
+- Move to C++11: smart pointers, etc.
+- Format of output has been changed. You no longer need to add a "display" gate to
+output the quantum state at the end of the circuit.
+- Now uses the new Libqasm API instead of the old one.
+- Output complex amplitudes when not averaging measurement register.
+- Do not add automatically a measure_all when doing measurement averaging;
+average the measurement register only.
+
+### Removed
+- Most preprocessor macros. E.g. for gate creation.
+- A lot of old and useless code was removed. A lot of dead code removed.
+
+### Fixed
+- Close input file when done.
+- Code style has been completely fixed automatically with clang-format.
+- Headers no longer include .cc file.
+- Moved implementations to .cc files instead of headers.
+
 ## [ 0.4.2 ] - [ 2021-06-01 ]
 ### Added
 -

--- a/include/qx/simulator.h
+++ b/include/qx/simulator.h
@@ -68,7 +68,12 @@ public:
     bool set(std::string file_path) {
         auto analyzer = cq::default_analyzer("1.2");
 
-        program = analyzer.analyze(file_path).unwrap();
+        try {
+            program = analyzer.analyze(file_path).unwrap();
+        } catch (const cq::analyzer::AnalysisFailed &e) {
+            error("Cannot parse and analyze file ", file_path);
+            return false;
+        }
 
         if (program.empty()) {
             error("Cannot parse and analyze file ", file_path);
@@ -82,6 +87,11 @@ public:
      * execute qasm file
      */
     void execute(size_t number_of_runs) {
+        if (program.empty()) {
+            error("No circuit loaded, call set(...) first");
+            return;
+        }
+
         // quantum state and circuits
         size_t qubits = program->num_qubits;
         std::vector<std::shared_ptr<qx::circuit>> circuits;

--- a/include/qx/version.h
+++ b/include/qx/version.h
@@ -1,4 +1,4 @@
 #ifndef QX_VERSION
-#define QX_VERSION "0.4.2"
+#define QX_VERSION "0.5"
 #define QX_RELEASE_YEAR "2022"
 #endif

--- a/setup.py
+++ b/setup.py
@@ -294,6 +294,7 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
 
         'Topic :: Scientific/Engineering'
     ],


### PR DESCRIPTION
### Added
- "-j <filename>" CLI option to output JSON to a file
- Possible to use the simulator without OpenMP.

### Changed
- Measure_all gate added; does no longer measure each qubit separately.
- Move to C++11: smart pointers, etc.
- Format of output has been changed. You no longer need to add a "display" gate to
output the quantum state at the end of the circuit.
- Now uses the new Libqasm API instead of the old one.

### Removed
- Most preprocessor macros. E.g. for gate creation.
- A lot of old and useless code was removed. A lot of dead code removed.

### Fixed
- Close input file when done.
- Code style has been completely fixed automatically with clang-format.
- Headers no longer include .cc file.
- Moved implementations to .cc files instead of headers.
