### PR TITLE
Release 0.6.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [ 0.6.4 ] - [ 2023-09-21 ]
+
+### Added
+
+- Meaningful error message when parsing or simulation fails
+
+### Changed
+
+- Does not crash when too many qubits asked
+
+### Removed
+
+-
+
 ## [ 0.6.3 ] - [ 2023-09-19 ]
 
 ### Added

--- a/include/qx/Core.hpp
+++ b/include/qx/Core.hpp
@@ -188,7 +188,7 @@ public:
         : numberOfQubits(n), data(1 << numberOfQubits) {
         assert(numberOfQubits > 0 && "QuantumState needs at least one qubit");
         assert(numberOfQubits <= config::MAX_QUBIT_NUMBER &&
-               "QuantumState currently cannot support that many qubits with this version of OpenQL");
+               "QuantumState currently cannot support that many qubits with this version of QX-simulator");
         data.set(BasisVector{}, 1);  // Start initialized in state 00...000
     };
 

--- a/include/qx/Qxelarator.hpp
+++ b/include/qx/Qxelarator.hpp
@@ -2,7 +2,6 @@
 
 #include "qx/Simulator.hpp"
 
-
 namespace qxelarator {
 
 // Old API (deprecated).
@@ -13,14 +12,17 @@ public:
         simulator.setJSONOutputPath(filePath);
     }
 
-    bool set(const std::string &filePath) { return simulator.set(filePath); }
+    std::optional<qx::SimulationError> set(const std::string &filePath) { return simulator.set(filePath); }
 
-    bool set_string(const std::string &s) { return simulator.setString(s); }
+    std::optional<qx::SimulationError> set_string(const std::string &s) { return simulator.setString(s); }
 
     std::string execute(std::size_t iterations = 1) {
-        auto simulationResult = simulator.execute(iterations);
-        assert(simulationResult);
-        return simulationResult->getJsonString();
+        auto result = simulator.execute(iterations);
+        if (auto* simulationError = std::get_if<qx::SimulationError>(&result)) {
+            return simulationError->message;
+        }
+
+        return std::get_if<qx::SimulationResult>(&result)->getJsonString();
     }
 
 private:
@@ -29,13 +31,13 @@ private:
 
 // New API.
 
-std::optional<qx::SimulationResult>
+std::variant<qx::SimulationResult, qx::SimulationError>
 execute_string(std::string const &s, std::size_t iterations = 1,
                std::optional<std::uint_fast64_t> seed = std::nullopt) {
     return qx::executeString(s, iterations, seed);
 }
 
-std::optional<qx::SimulationResult>
+std::variant<qx::SimulationResult, qx::SimulationError>
 execute_file(std::string const &filePath, std::size_t iterations = 1,
              std::optional<std::uint_fast64_t> seed = std::nullopt) {
     return qx::executeFile(filePath, iterations, seed);

--- a/include/qx/Simulator.hpp
+++ b/include/qx/Simulator.hpp
@@ -3,11 +3,15 @@
 #include "cqasm.hpp"
 #include "qx/SimulationResult.hpp"
 
-#include <optional>
+#include <variant>
 #include <string>
 
 
 namespace qx {
+
+struct SimulationError {
+    std::string message = "Simulation error";
+};
 
 // Old API (deprecated).
 class Simulator {
@@ -16,11 +20,11 @@ public:
         jsonOutputFilePath = filePath;
     }
 
-    bool set(std::string const &filePath);
+    std::optional<SimulationError> set(std::string const &filePath);
 
-    bool setString(std::string const &s);
+    std::optional<SimulationError> setString(std::string const &s);
 
-    [[nodiscard]] std::optional<SimulationResult>
+    [[nodiscard]] std::variant<SimulationResult, SimulationError>
     execute(std::size_t iterations = 1,
             std::optional<std::uint_fast64_t> seed = std::nullopt) const;
 
@@ -30,11 +34,11 @@ private:
 };
 
 // New API.
-std::optional<SimulationResult>
+std::variant<SimulationResult, SimulationError>
 executeString(std::string const &s, std::size_t iterations = 1,
               std::optional<std::uint_fast64_t> seed = std::nullopt);
 
-std::optional<SimulationResult>
+std::variant<SimulationResult, SimulationError>
 executeFile(std::string const &filePath, std::size_t iterations = 1,
             std::optional<std::uint_fast64_t> seed = std::nullopt);
 

--- a/include/qx/Version.hpp
+++ b/include/qx/Version.hpp
@@ -1,4 +1,4 @@
 #ifndef QX_VERSION
-#define QX_VERSION "0.6.3"
+#define QX_VERSION "0.6.4"
 #define QX_RELEASE_YEAR "2023"
 #endif

--- a/python/Qxelarator.i
+++ b/python/Qxelarator.i
@@ -15,8 +15,8 @@
 }
 
 // Map the output of execute_string/execute_file to a simple Python class for user-friendliness.
-%typemap(out) std::optional<qx::SimulationResult> {
-    if ($1) {
+%typemap(out) std::variant<qx::SimulationResult, qx::SimulationError> {
+    if (std::holds_alternative<qx::SimulationResult>($1)) {
         auto pmod = PyImport_ImportModule("qxelarator");
         auto pclass = PyObject_GetAttrString(pmod, "SimulationResult");
         Py_DECREF(pmod);
@@ -24,17 +24,19 @@
         auto simulationResult = PyObject_CallObject(pclass, NULL);
         Py_DECREF(pclass);
 
-        PyObject_SetAttrString(simulationResult, "shots_done", PyLong_FromUnsignedLongLong($1->shots_done));
-        PyObject_SetAttrString(simulationResult, "shots_requested", PyLong_FromUnsignedLongLong($1->shots_requested));
+        auto const* cppSimulationResult = std::get_if<qx::SimulationResult>(&$1);
+
+        PyObject_SetAttrString(simulationResult, "shots_done", PyLong_FromUnsignedLongLong(cppSimulationResult->shots_done));
+        PyObject_SetAttrString(simulationResult, "shots_requested", PyLong_FromUnsignedLongLong(cppSimulationResult->shots_requested));
 
         auto results = PyDict_New();
-        for(auto const& x: $1->results) {
+        for(auto const& x: cppSimulationResult->results) {
             PyDict_SetItemString(results, x.first.c_str(), PyLong_FromUnsignedLongLong(x.second));
         }
         PyObject_SetAttrString(simulationResult, "results", results);
 
         auto state = PyDict_New();
-        for(auto const& x: $1->state) {
+        for(auto const& x: cppSimulationResult->state) {
             PyDict_SetItemString(state, x.first.c_str(), PyComplex_FromCComplex({ .real = x.second.real, .imag = x.second.imag }));
         }
         PyObject_SetAttrString(simulationResult, "state", state);
@@ -45,8 +47,7 @@
         auto pclass = PyObject_GetAttrString(pmod, "SimulationError");
         Py_DECREF(pmod);
 
-        // TODO: return meaningful error message.
-        auto errorString = PyUnicode_FromString("Simulation failed!");
+        auto errorString = PyUnicode_FromString(std::get_if<qx::SimulationError>(&$1)->message.c_str());
         auto args = PyTuple_Pack(1, errorString);
 
         auto simulationError = PyObject_CallObject(pclass, args);

--- a/src/qx-simulator/Simulator.cpp
+++ b/src/qx-simulator/Simulator.cpp
@@ -82,11 +82,11 @@ int main(int argc, char **argv) {
     simulator.setJSONOutputPath(jsonFilename);
     auto simulationResult = simulator.execute(iterations);
 
-    if (!simulationResult) {
-        std::cerr << "Simulation failed." << std::endl;
+    if (auto* error = std::get_if<qx::SimulationError>(&simulationResult)) {
+        std::cerr << error->message << std::endl;
         return 1;
     }
 
-    std::cout << *simulationResult << std::endl;
+    std::cout << *std::get_if<qx::SimulationResult>(&simulationResult) << std::endl;
     return 0;
 }

--- a/src/qx/Simulator.cpp
+++ b/src/qx/Simulator.cpp
@@ -86,6 +86,11 @@ Simulator::execute(std::size_t iterations,
     }
 
     std::size_t qubitCount = program->num_qubits;
+
+    if (qubitCount > config::MAX_QUBIT_NUMBER) {
+        return {};
+    }
+
     std::vector<qx::Circuit> perfectCircuits;
 
     qx::core::QuantumState quantumState(qubitCount);

--- a/tests/IntegrationTest.cpp
+++ b/tests/IntegrationTest.cpp
@@ -3,6 +3,7 @@
 
 #include <cassert>
 #include <gtest/gtest.h>
+#include <gmock/gmock.h>
 
 
 namespace qx {
@@ -11,9 +12,9 @@ class IntegrationTest : public ::testing::Test {
 public:
     static SimulationResult runFromString(const std::string &s,
                                           std::uint64_t iterations = 1) {
-        auto simulationResult = executeString(s, iterations);
-        assert(simulationResult.has_value());
-        return *simulationResult;
+        auto result = executeString(s, iterations);
+        EXPECT_TRUE(std::holds_alternative<SimulationResult>(result));
+        return *std::get_if<SimulationResult>(&result);
     }
 
 private:
@@ -184,11 +185,27 @@ measure_z q[9:16]
 }
 
 TEST_F(IntegrationTest, too_many_qubits) {
-    EXPECT_TRUE(executeString("version 1.0; qubits 62"));
-    EXPECT_TRUE(executeString("version 1.0; qubits 63"));
-    EXPECT_TRUE(executeString("version 1.0; qubits 64"));
-    EXPECT_FALSE(executeString("version 1.0; qubits 65"));
-    EXPECT_FALSE(executeString("version 1.0; qubits 66"));
+    EXPECT_TRUE(std::holds_alternative<SimulationResult>(executeString("version 1.0; qubits 62")));
+    EXPECT_TRUE(std::holds_alternative<SimulationResult>(executeString("version 1.0; qubits 63")));
+    EXPECT_TRUE(std::holds_alternative<SimulationResult>(executeString("version 1.0; qubits 64")));
+    EXPECT_TRUE(std::holds_alternative<SimulationError>(executeString("version 1.0; qubits 65")));
+    EXPECT_TRUE(std::holds_alternative<SimulationError>(executeString("version 1.0; qubits 66")));
+}
+
+TEST_F(IntegrationTest, syntax_error) {
+    auto cqasm = R"(
+version 1.0
+
+qubits 1
+
+h q[0
+)";
+
+    auto result = executeString(cqasm);
+    EXPECT_TRUE(std::holds_alternative<SimulationError>(result));
+    EXPECT_THAT(std::get_if<SimulationError>(&result)->message, ::testing::StartsWith("""\
+Cannot parse and analyze string \nversion 1.0\n\nqubits 1\n\nh q[0\n: \n\
+<unknown>:6:6: syntax error, unexpected NEWLINE"""));
 }
 
 TEST_F(IntegrationTest, unknown_error_model) {
@@ -200,7 +217,7 @@ qubits 1
 error_model amplitude_damping, 0.1
 )";
 
-    EXPECT_FALSE(executeString(cqasm));
+    EXPECT_TRUE(std::holds_alternative<SimulationError>(executeString(cqasm)));
 }
 
 TEST_F(IntegrationTest, depolarizing_channel_with_constant_seed) {

--- a/tests/IntegrationTest.cpp
+++ b/tests/IntegrationTest.cpp
@@ -183,6 +183,14 @@ measure_z q[9:16]
                   {"00001000111111100", {1 / std::sqrt(8), 0, 0.125}}}));
 }
 
+TEST_F(IntegrationTest, too_many_qubits) {
+    EXPECT_TRUE(executeString("version 1.0; qubits 62"));
+    EXPECT_TRUE(executeString("version 1.0; qubits 63"));
+    EXPECT_TRUE(executeString("version 1.0; qubits 64"));
+    EXPECT_FALSE(executeString("version 1.0; qubits 65"));
+    EXPECT_FALSE(executeString("version 1.0; qubits 66"));
+}
+
 TEST_F(IntegrationTest, unknown_error_model) {
     auto cqasm = R"(
 version 1.0

--- a/tests/qxelarator/test_Qxelarator.py
+++ b/tests/qxelarator/test_Qxelarator.py
@@ -39,7 +39,7 @@ class QxelaratorTest(unittest.TestCase):
         self.assertEqual(simulationResult.results, {"00": 23})
         self.assertEqual(simulationResult.state, {"11": complex(1., 0.)})
 
-    def test_execute_string_fails_returns_none(self):
+    def test_execute_string_fails_returns_simulation_error(self):
         cQasmString = \
 """
 version 1.0
@@ -53,7 +53,18 @@ qubits 1
         simulationError = qxelarator.execute_string(cQasmString, iterations = 2)
 
         self.assertIsInstance(simulationError, qxelarator.SimulationError)
-        self.assertEqual(simulationError.message, "Simulation failed!")
+        self.assertEqual(simulationError.message, """\
+Cannot parse and analyze string 
+version 1.0
+
+qubits 1
+
+.myCircuit
+    x q[0],
+    measure q[0]
+: 
+<unknown>:7:12: syntax error, unexpected NEWLINE
+""")
 
     def test_execute_string(self):
         cQasmString = \


### PR DESCRIPTION
- Do not crash when too many qubits
- Return meaningful error message in SimulationError Python type (errors coming from libqasm and from the simulator itself)

Those two behaviours are very much desired for the tutorial.