### PR TITLE
Update to use `libqasm` Conan package

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,11 +26,12 @@ jobs:
         with:
           build_type: ${{ matrix.build_type }}
           conan_profile_host: conan/profiles/tests-${{ matrix.build_type }}-${{ matrix.compiler }}-linux-x64
+          conan_profile_build: conan/profiles/tests-${{ matrix.build_type }}-${{ matrix.compiler }}-linux-x64
           shell: bash
 
   cpp-macos-x64:
     name: "C++ tests (clang/MacOS/x64)"
-    runs-on: macos-latest
+    runs-on: macos-13  # x64
     strategy:
       fail-fast: false
       matrix:
@@ -44,6 +45,7 @@ jobs:
         with:
           build_type: ${{ matrix.build_type }}
           conan_profile_host: conan/profiles/tests-${{ matrix.build_type }}-apple_clang-macos-x64
+          conan_profile_build: conan/profiles/tests-${{ matrix.build_type }}-apple_clang-macos-x64
           shell: bash
 
   cpp-windows-x64:
@@ -87,11 +89,12 @@ jobs:
         with:
           build_type: Release
           conan_profile_host: conan/profiles/tests-release-gcc-linux-arm64
+          conan_profile_build: conan/profiles/tests-release-gcc-linux-arm64
           shell: bash
 
   cpp-macos-arm64:
     name: "C++ tests (clang/macos/ARM64)"
-    runs-on: [self-hosted, ARM64, macOS]
+    runs-on: macos-14  # arm64
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -107,6 +110,7 @@ jobs:
         with:
           build_type: Release
           conan_profile_host: conan/profiles/tests-release-apple_clang-macos-arm64
+          conan_profile_build: conan/profiles/tests-release-apple_clang-macos-arm64
           shell: bash
 
   python-linux-x64:
@@ -125,7 +129,21 @@ jobs:
 
   python-macos-x64:
     name: "Python tests (macOS/x64)"
-    runs-on: macos-latest
+    runs-on: macos-13
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install SWIG
+        run: |
+          brew install swig
+        shell: bash
+      - uses: ./.github/actions/python-tests
+        with:
+          shell: bash
+
+  python-macos-arm64:
+    name: "Python tests (macOS/arm64)"
+    runs-on: macos-14
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -158,6 +176,7 @@ jobs:
       - cpp-macos-arm64
       - python-linux-x64
       - python-macos-x64
+      - python-macos-arm64
       - python-windows-x64
     if: ${{ always() }}
     runs-on: ubuntu-latest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,15 +110,8 @@ set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 # Dependencies                                                                #
 #=============================================================================#
 
-find_package(absl)
-
-# libqasm 0.6.3
-message(STATUS "Fetching cqasm")
-FetchContent_Declare(cqasm
-    GIT_REPOSITORY https://github.com/QuTech-Delft/libqasm.git
-    GIT_TAG "4240fe9fd52e3e8da1585091d6f7ac5ae105271f"
-)
-FetchContent_MakeAvailable(cqasm)
+find_package(absl REQUIRED)
+find_package(libqasm REQUIRED CONFIG)
 
 
 #=============================================================================#
@@ -203,7 +196,7 @@ endif()
 
 target_link_libraries(qx PUBLIC
     absl::flat_hash_map
-    cqasm
+    libqasm::libqasm
 )
 
 #=============================================================================#

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,7 +110,7 @@ set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 # Dependencies                                                                #
 #=============================================================================#
 
-find_package(absl REQUIRED)
+find_package(absl)
 find_package(libqasm REQUIRED CONFIG)
 
 

--- a/conan/profiles/debug
+++ b/conan/profiles/debug
@@ -7,5 +7,7 @@ build_type=Debug
 [options]
 qx/*:asan_enabled=False
 qx/*:build_python=False
-qx/*:build_tests=False
 qx/*:cpu_compatibility_mode=False
+
+[conf]
+tools.build:skip_test=True

--- a/conan/profiles/release
+++ b/conan/profiles/release
@@ -7,5 +7,7 @@ build_type=Release
 [options]
 qx/*:asan_enabled=False
 qx/*:build_python=False
-qx/*:build_tests=False
 qx/*:cpu_compatibility_mode=False
+
+[conf]
+tools.build:skip_test=True

--- a/conan/profiles/tests-debug
+++ b/conan/profiles/tests-debug
@@ -7,5 +7,4 @@ build_type=Debug
 [options]
 qx/*:asan_enabled=False
 qx/*:build_python=False
-qx/*:build_tests=True
 qx/*:cpu_compatibility_mode=False

--- a/conan/profiles/tests-release
+++ b/conan/profiles/tests-release
@@ -7,5 +7,4 @@ build_type=Release
 [options]
 qx/*:asan_enabled=False
 qx/*:build_python=False
-qx/*:build_tests=True
 qx/*:cpu_compatibility_mode=False

--- a/conanfile.py
+++ b/conanfile.py
@@ -42,15 +42,12 @@ class QxConan(ConanFile):
         return not self.conf.get("tools.build:skip_test", default=True, check_type=bool)
 
     def build_requirements(self):
-        self.tool_requires("abseil/20230125.3")
         self.tool_requires("libqasm/0.6.5")
-        if self.settings.arch != "armv8":
-            self.tool_requires("zulu-openjdk/11.0.19")
         if self._should_build_test:
             self.test_requires("gtest/1.14.0")
 
     def requirements(self):
-        self.requires("antlr4-cppruntime/4.13.1")
+        self.requires("abseil/20230125.3")
         self.requires("fmt/10.2.1")
         self.requires("libqasm/0.6.5")
 

--- a/setup.py
+++ b/setup.py
@@ -97,7 +97,6 @@ class build_ext(_build_ext):
                 ['-s:b']['build_type=' + build_type]
 
                 ['-o']['qx/*:build_python=True']
-                ['-o']['qx/*:build_tests=' + build_tests]
                 ['-o']['qx/*:cpu_compatibility_mode=' + cpu_compatibility_mode]
                 # The Python library needs the compatibility headers
                 ['-o']['qx/*:python_dir=' + re.escape(os.path.dirname(target))]
@@ -109,6 +108,8 @@ class build_ext(_build_ext):
                 ['-b']['missing']
                 ['-tf']['']
             )
+            if not build_tests:
+                cmd = cmd['-c']['tools.build:skip_test=True']
             if platform.system() == "Darwin":
                 cmd = cmd['-c']['tools.build:defines=["_LIBCPP_DISABLE_AVAILABILITY"]']
             cmd & FG


### PR DESCRIPTION
Update `conanfile.py` to:
- request `libqasm/0.6.5`, and
- use `tools.build.skip_test`, instead of `qx/*:build_tests`.

Update `CMakeLists.txt` to:
- `find_package(libqasm)`, and
- link against `libqasm::libqasm`.

Update GitHub workflows with some improvements taken from `libqasm`.