### PR TITLE
[CQT-138] Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Build outputs may go into:
 This version of QX Simulator can only be compiled via the Conan package manager.
 You'll need to create a default profile before using it for the first time.
 
-The installation of dependencies, as well as the compilation, can be done in one go.
+The installation and compilation of dependencies can be done in one go.
 
 ```shell
 git clone https://github.com/QuTech-Delft/qx-simulator.git


### PR DESCRIPTION
This task is part of a greater task of updating the documentation for the whole of the cQASM tooling.

README files have to be updated. Some information needs to be added, modified, deleted, or moved to other documentation hosting systems (e.g., GitHub pages, ReadTheDocs, or Confluence).

The README files across the cQASM tooling should look consistent.