### PR TITLE
[CQT-26] Manage bit (register) variables

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,7 +112,9 @@ set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 
 find_package(absl)
 find_package(Boost REQUIRED)
-find_package(libqasm REQUIRED CONFIG)
+find_package(fmt REQUIRED)
+find_package(libqasm REQUIRED)
+find_package(range-v3 REQUIRED)
 
 
 #=============================================================================#
@@ -143,6 +145,9 @@ target_compile_features(qx PRIVATE
 target_include_directories(qx PUBLIC
     "${CMAKE_CURRENT_SOURCE_DIR}/include/"
     "${Boost_INCLUDE_DIRS}"
+    "${fmt_INCLUDE_DIRS}"
+    "${libqasm_INCLUDE_DIRS}"
+    "${range-v3_INCLUDE_DIRS}"
 )
 
 if(CMAKE_COMPILER_IS_GNUCXX)
@@ -201,9 +206,11 @@ endif()
 # Configure, build, and link dependencies                                     #
 #=============================================================================#
 
-target_link_libraries(qx PUBLIC
-    absl::flat_hash_map
-    libqasm::libqasm
+target_link_libraries(qx
+    PUBLIC absl::flat_hash_map
+    PUBLIC fmt::fmt
+    PUBLIC libqasm::libqasm
+    PUBLIC range-v3::range-v3
 )
 
 #=============================================================================#
@@ -213,8 +220,8 @@ target_link_libraries(qx PUBLIC
 add_executable(qx-simulator
     "${CMAKE_CURRENT_SOURCE_DIR}/src/qx-simulator/Simulator.cpp"
 )
-target_link_libraries(qx-simulator PRIVATE
-    qx
+target_link_libraries(qx-simulator
+    PRIVATE qx
 )
 
 #=============================================================================#
@@ -247,6 +254,9 @@ message(STATUS
     "[${PROJECT_NAME}] Target include directories:\n"
     "      CMAKE_CURRENT_SOURCE_DIR/include/: ${CMAKE_CURRENT_SOURCE_DIR}/include/\n"
     "      Boost_INCLUDE_DIRS: ${Boost_INCLUDE_DIRS}\n"
+    "      fmt_INCLUDE_DIRS: ${fmt_INCLUDE_DIRS}\n"
+    "      libqasm_INCLUDE_DIRS: ${libqasm_INCLUDE_DIRS}\n"
+    "      range-v3_INCLUDE_DIRS: ${range-v3_INCLUDE_DIRS}\n"
 )
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,6 +111,7 @@ set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 #=============================================================================#
 
 find_package(absl)
+find_package(Boost REQUIRED)
 find_package(libqasm REQUIRED CONFIG)
 
 
@@ -141,6 +142,7 @@ target_compile_features(qx PRIVATE
 
 target_include_directories(qx PUBLIC
     "${CMAKE_CURRENT_SOURCE_DIR}/include/"
+    "${Boost_INCLUDE_DIRS}"
 )
 
 if(CMAKE_COMPILER_IS_GNUCXX)
@@ -244,6 +246,7 @@ endif()
 message(STATUS
     "[${PROJECT_NAME}] Target include directories:\n"
     "      CMAKE_CURRENT_SOURCE_DIR/include/: ${CMAKE_CURRENT_SOURCE_DIR}/include/\n"
+    "      Boost_INCLUDE_DIRS: ${Boost_INCLUDE_DIRS}\n"
 )
 
 

--- a/conan/profiles/base
+++ b/conan/profiles/base
@@ -1,0 +1,4 @@
+include(default)
+
+[options]
+boost/*:header_only=True

--- a/conan/profiles/debug
+++ b/conan/profiles/debug
@@ -1,4 +1,4 @@
-include(default)
+include(base)
 
 [settings]
 compiler.cppstd=23

--- a/conan/profiles/release
+++ b/conan/profiles/release
@@ -1,4 +1,4 @@
-include(default)
+include(base)
 
 [settings]
 compiler.cppstd=23

--- a/conan/profiles/tests-debug
+++ b/conan/profiles/tests-debug
@@ -1,4 +1,4 @@
-include(default)
+include(base)
 
 [settings]
 compiler.cppstd=23

--- a/conan/profiles/tests-release
+++ b/conan/profiles/tests-release
@@ -1,4 +1,4 @@
-include(default)
+include(base)
 
 [settings]
 compiler.cppstd=23

--- a/conanfile.py
+++ b/conanfile.py
@@ -48,6 +48,7 @@ class QxConan(ConanFile):
 
     def requirements(self):
         self.requires("abseil/20230125.3", transitive_headers=True)
+        self.requires("boost/1.85.0")
         self.requires("fmt/10.2.1", transitive_headers=True)
         self.requires("libqasm/0.6.6", transitive_headers=True)
         self.requires("range-v3/0.12.0", transitive_headers=True)

--- a/include/qx/CompileTimeConfiguration.hpp
+++ b/include/qx/CompileTimeConfiguration.hpp
@@ -19,4 +19,8 @@ static constexpr std::uint64_t ZERO_CYCLE_SIZE = 100;
 // Maybe memory-saving as a multiple of 64.
 static constexpr std::size_t MAX_QUBIT_NUMBER = 64;
 
+// Maximum number of bits that can be used.
+// Just for sanity, as we maintain vectors of the size of the number of used bits.
+static constexpr std::size_t MAX_BIT_NUMBER = 1*1024*1024;  // 1 MB
+
 }  // namespace qx::config

--- a/include/qx/Core.hpp
+++ b/include/qx/Core.hpp
@@ -1,8 +1,10 @@
 #pragma once
 
+#include <boost/dynamic_bitset/dynamic_bitset.hpp>
 #include <cstdint>  // size_t, uint32_t
 #include <cstdlib>  // abs
 #include <complex>
+#include <fmt/ostream.h>
 
 #include "qx/CompileTimeConfiguration.hpp"  // EPS, MAX_QUBIT_NUMBER
 #include "qx/Utils.hpp"
@@ -26,7 +28,13 @@ struct QubitIndex {
     std::size_t value;
 };
 
+struct BitIndex {
+    std::size_t value;
+};
+
 using BasisVector = utils::Bitset<config::MAX_QUBIT_NUMBER>;
+
+using BitMeasurementRegister = boost::dynamic_bitset<uint32_t>;
 
 inline constexpr bool isNotNull(std::complex<double> c) {
 #if defined(_MSC_VER)
@@ -43,3 +51,5 @@ inline constexpr bool isNull(std::complex<double> c) {
 }
 
 }  // namespace qx::core
+
+template <> struct fmt::formatter<qx::core::BitMeasurementRegister> : fmt::ostream_formatter {};

--- a/include/qx/Instructions.hpp
+++ b/include/qx/Instructions.hpp
@@ -15,6 +15,7 @@ namespace qx {
 
 struct Measure {
     core::QubitIndex qubitIndex{};
+    core::BitIndex bitIndex{};
 };
 
 struct MeasurementRegisterOperation {

--- a/include/qx/QuantumState.hpp
+++ b/include/qx/QuantumState.hpp
@@ -50,10 +50,11 @@ class QuantumState {
     void checkQuantumState();
 
 public:
-    QuantumState(std::size_t qubit_register_size);
-    QuantumState(std::size_t qubit_register_size,
+    QuantumState(std::size_t qubit_register_size, std::size_t bit_register_size);
+    QuantumState(std::size_t qubit_register_size, std::size_t bit_register_size,
                  std::initializer_list<std::pair<std::string, std::complex<double>>> values);
     [[nodiscard]] std::size_t getNumberOfQubits() const;
+    [[nodiscard]] std::size_t getNumberOfBits() const;
     [[nodiscard]] bool isNormalized();
     void reset();
 
@@ -82,23 +83,30 @@ public:
     }
 
     [[nodiscard]] const BasisVector &getMeasurementRegister() const;
+    [[nodiscard]] const BitMeasurementRegister &getBitMeasurementRegister() const;
     [[nodiscard]] double getProbabilityOfMeasuringOne(QubitIndex qubitIndex);
     [[nodiscard]] double getProbabilityOfMeasuringZero(QubitIndex qubitIndex);
     void collapseQubitState(QubitIndex qubitIndex, bool measuredState, double probabilityOfMeasuringOne);
 
     // measuredState will be true if we measured a 1, or false if we measured a 0
     template <typename F>
-    void measure(QubitIndex qubitIndex, F &&randomGenerator) {
+    void measure(QubitIndex qubitIndex, BitIndex bitIndex, F &&randomGenerator) {
         auto probabilityOfMeasuringOne = getProbabilityOfMeasuringOne(qubitIndex);
         auto measuredState = (randomGenerator() < probabilityOfMeasuringOne);
         collapseQubitState(qubitIndex, measuredState, probabilityOfMeasuringOne);
         measurementRegister.set(qubitIndex.value, measuredState);
+        bitMeasurementRegister.set(bitIndex.value, measuredState);
     }
 
 private:
     std::size_t numberOfQubits = 1;
+    std::size_t numberOfBits = 1;
     SparseArray data;
+    // TODO: we are keeping a "double-entry bookkeeping" until we can get rid of measurements
+    //   measurements needs to be replaced with bitMeasurements with the introduction of bit variables,
+    //   but this replacement cannot be executed until all the QX simulator clients start using bitMeasurements
     BasisVector measurementRegister{};
+    BitMeasurementRegister bitMeasurementRegister{};
 };
 
 }  // namespace qx::core

--- a/include/qx/QuantumState.hpp
+++ b/include/qx/QuantumState.hpp
@@ -102,9 +102,6 @@ private:
     std::size_t numberOfQubits = 1;
     std::size_t numberOfBits = 1;
     SparseArray data;
-    // TODO: we are keeping a "double-entry bookkeeping" until we can get rid of measurements
-    //   measurements needs to be replaced with bitMeasurements with the introduction of bit variables,
-    //   but this replacement cannot be executed until all the QX simulator clients start using bitMeasurements
     BasisVector measurementRegister{};
     BitMeasurementRegister bitMeasurementRegister{};
 };

--- a/include/qx/RegisterManager.hpp
+++ b/include/qx/RegisterManager.hpp
@@ -5,6 +5,8 @@
 #include "v3x/cqasm-semantic-gen.hpp"
 
 #include <cstdint>  // size_t
+#include <fmt/ostream.h>
+#include <optional>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -12,37 +14,70 @@
 
 namespace qx {
 
-using VariableName = std::string;
-
-struct QubitRange {
-    std::size_t first;
-    std::size_t size;
-};
-
-struct RegisterManagerError : public SimulationError {
-    explicit RegisterManagerError(const std::string &message);
-};
-
 /*
- * RegisterManager keeps track of a (virtual) qubit register, i.e., an array of consecutive qubits,
- * and the mappings between the (logical) qubit variable names, as used in an input cQASM program,
- * and the (virtual) qubit register.
+ * RegisterManager keeps track of a (virtual) qubit register and a (virtual) bit register.
+ * I.e., an array of consecutive qubits/bits, and the mappings between the (logical) qubit/bit variable names,
+ * as used in an input cQASM program, and the (virtual) qubit/bit register.
  *
  * For example, given an input program that defines 'qubit[3] q':
  * - variable 'q' is mapped to qubits 0 to 2 in the qubit register, and
  * - positions 0 to 2 in the qubit register are mapped to variable 'q'.
  *
- * The mapping of qubit variable names to positions in the qubit register is an implementation detail,
- * i.e., it is not guaranteed that qubit register indices are assigned to qubit variable names in the order
+ * The mapping of qubit/bit variable names to positions in the qubit/bit register is an implementation detail,
+ * i.e., it is not guaranteed that qubit/bit register indices are assigned to qubit/bit variable names in the order
  * these variables are defined in the input program.
  */
+
+
+using VariableName = std::string;
+
+using Index = std::size_t;
+
+struct Range {
+    Index first;
+    Index size;
+};
+
+
+struct RegisterManagerError : public SimulationError {
+    explicit RegisterManagerError(const std::string &message);
+};
+
+using VariableNameToRangeMapT = std::unordered_map<VariableName, Range>;
+using IndexToVariableNameMapT = std::vector<VariableName>;
+
+class Register {
+    std::size_t register_size_;
+    VariableNameToRangeMapT variable_name_to_range_;
+    IndexToVariableNameMapT index_to_variable_name_;
+public:
+    Register(const V3OneProgram &program, auto &&is_of_type, std::size_t max_register_size);
+    virtual ~Register() = 0;
+    [[nodiscard]] std::size_t size() const;
+    [[nodiscard]] virtual Range at(const VariableName &name) const;
+    [[nodiscard]] virtual Index at(const VariableName &name, const std::optional<Index> &subIndex) const;
+    [[nodiscard]] virtual VariableName at(const std::size_t &index) const;
+    [[nodiscard]] virtual std::string toString() const;
+};
+
+
+class QubitRegister : public Register {
+public:
+    explicit QubitRegister(const V3OneProgram &program);
+    ~QubitRegister() override;
+};
+
+
+class BitRegister : public Register {
+public:
+    explicit BitRegister(const V3OneProgram &program);
+    ~BitRegister() override;
+};
+
+
 class RegisterManager {
-    using VariableNameToQubitRangeMapT = std::unordered_map<VariableName, QubitRange>;
-    using QubitIndexToVariableNameMapT = std::vector<VariableName>;
-private:
-    std::size_t qubit_register_size_;
-    VariableNameToQubitRangeMapT variable_name_to_qubit_range_;
-    QubitIndexToVariableNameMapT qubit_index_to_variable_name_;
+    QubitRegister qubit_register_;
+    BitRegister bit_register_;
 public:
     RegisterManager(const RegisterManager&) = delete;
     RegisterManager(RegisterManager&&) noexcept = delete;
@@ -51,8 +86,26 @@ public:
 public:
     explicit RegisterManager(const V3OneProgram &program);
     [[nodiscard]] std::size_t get_qubit_register_size() const;
-    [[nodiscard]] QubitRange get_qubit_range(const VariableName &name) const;
-    [[nodiscard]] VariableName get_variable_name(std::size_t index) const;
+    [[nodiscard]] std::size_t get_bit_register_size() const;
+    [[nodiscard]] Range get_qubit_range(const VariableName &name) const;
+    [[nodiscard]] Range get_bit_range(const VariableName &name) const;
+    [[nodiscard]] Index get_qubit_index(const VariableName &name, const std::optional<Index> &subIndex) const;
+    [[nodiscard]] Index get_bit_index(const VariableName &name, const std::optional<Index> &subIndex) const;
+    [[nodiscard]] VariableName get_qubit_variable_name(const Index &index) const;
+    [[nodiscard]] VariableName get_bit_variable_name(const Index &index) const;
+    [[nodiscard]] QubitRegister const& get_qubit_register() const;
+    [[nodiscard]] BitRegister const& get_bit_register() const;
 };
 
+
+std::ostream& operator<<(std::ostream& os, Range const& range);
+std::ostream& operator<<(std::ostream& os, QubitRegister const& qubitRegister);
+std::ostream& operator<<(std::ostream& os, BitRegister const& bitRegister);
+
+
 }  // namespace qx
+
+
+template <> struct fmt::formatter<qx::Range> : fmt::ostream_formatter {};
+template <> struct fmt::formatter<qx::QubitRegister> : fmt::ostream_formatter {};
+template <> struct fmt::formatter<qx::BitRegister> : fmt::ostream_formatter {};

--- a/include/qx/SimulationResult.hpp
+++ b/include/qx/SimulationResult.hpp
@@ -1,8 +1,9 @@
 #pragma once
 
 #include "qx/CompileTimeConfiguration.hpp"
-#include "qx/Core.hpp"  // BasisVector, Complex
+#include "qx/Core.hpp"  // BasisVector, BitMeasurementRegister Complex
 #include "qx/QuantumState.hpp"
+#include "qx/RegisterManager.hpp"
 
 #include <absl/container/btree_map.h>
 #include <compare>  // partial_ordering
@@ -49,14 +50,31 @@ struct SimulationResult {
     using State = std::vector<SuperposedState>;
 
 public:
-    SimulationResult(std::uint64_t requestedShots, std::uint64_t doneShots);
+    SimulationResult(std::uint64_t requestedShots, std::uint64_t doneShots, RegisterManager const& registerManager);
+
+    // Given a state string from the State vector, a qubit variable name, and an optional sub index,
+    // return the value of that qubit in the state string
+    // The sub index is used to access a given qubit when the qubit variable is of array type
+    // Notice that the final index in the state string is determined by the qubit register
+    std::uint8_t getQubitState(state_string_t const& stateString, std::string const& qubitVariableName,
+                               std::optional<Index> subIndex);
+    // Given a state string from the State vector, a bit variable name, and an optional sub index,
+    // return the value of that bit in the state string
+    // The sub index is used to access a given bit when the bit variable is of array type
+    // Notice that the final index in the state string is determined by the bit register
+    std::uint8_t getBitMeasurement(state_string_t const& stateString, std::string const& bitVariableName,
+                                   std::optional<Index> subIndex);
 
 public:
     std::uint64_t shotsRequested;
     std::uint64_t shotsDone;
 
+    QubitRegister qubitRegister;
+    BitRegister bitRegister;
+
     State state;
     Measurements measurements;
+    Measurements bitMeasurements;
 };
 
 std::ostream &operator<<(std::ostream &os, const SimulationResult &result);
@@ -66,7 +84,8 @@ class SimulationResultAccumulator {
 public:
     explicit SimulationResultAccumulator(core::QuantumState &s);
     void appendMeasurement(core::BasisVector const& measurement);
-    SimulationResult getSimulationResult();
+    void appendBitMeasurement(core::BitMeasurementRegister const& bitMeasurement);
+    SimulationResult getSimulationResult(RegisterManager const& registerManager);
 
 private:
     template <typename F>
@@ -77,8 +96,15 @@ private:
     }
 
     core::QuantumState &state;
+
+    // TODO: we are keeping a "double-entry bookkeeping" until we can get rid of measurements
+    //   measurements needs to be replaced with bitMeasurements with the introduction of bit variables,
+    //   but this replacement cannot be executed until all the QX simulator clients start using bitMeasurements
     absl::btree_map<state_string_t, count_t> measurements;
+    absl::btree_map<state_string_t, count_t> bitMeasurements;
+
     std::uint64_t measurementsCount = 0;
+    std::uint64_t bitMeasurementsCount = 0;
 };
 
 

--- a/include/qx/SimulationResult.hpp
+++ b/include/qx/SimulationResult.hpp
@@ -96,10 +96,6 @@ private:
     }
 
     core::QuantumState &state;
-
-    // TODO: we are keeping a "double-entry bookkeeping" until we can get rid of measurements
-    //   measurements needs to be replaced with bitMeasurements with the introduction of bit variables,
-    //   but this replacement cannot be executed until all the QX simulator clients start using bitMeasurements
     absl::btree_map<state_string_t, count_t> measurements;
     absl::btree_map<state_string_t, count_t> bitMeasurements;
 

--- a/include/qx/V3xLibqasmInterface.hpp
+++ b/include/qx/V3xLibqasmInterface.hpp
@@ -29,5 +29,6 @@ using V3Value = v3_values::Value;
 using V3Variable = v3_semantic::Variable;
 
 bool is_qubit_variable(const V3Variable &variable);
+bool is_bit_variable(const V3Variable &variable);
 
 }  // namespace qx

--- a/setup.py
+++ b/setup.py
@@ -94,6 +94,7 @@ class build_ext(_build_ext):
                 ['-s:a']['compiler.cppstd=23']
                 ['-s:a']['build_type=' + build_type]
 
+                ['-o:a']['boost/*:header_only=True']
                 ['-o:a']['qx/*:build_python=True']
                 ['-o:a']['qx/*:cpu_compatibility_mode=' + cpu_compatibility_mode]
                 # The Python library needs the compatibility headers

--- a/src/qx/GateConvertor.cpp
+++ b/src/qx/GateConvertor.cpp
@@ -132,12 +132,14 @@ void GateConvertor::addGates(const V3Instruction &instruction) {
         // A measure statement has the following syntax: b = measure q
         // The left-hand side operand, b, is the operand 0
         // The right-hand side operand, q, is the operand 1
+        const auto &bit_indices = operands_helper.get_register_operand(0);
         const auto &qubit_indices = operands_helper.get_register_operand(1);
         auto controlBits = std::make_shared<std::vector<core::QubitIndex>>();
         for (size_t i{ 0 }; i < qubit_indices.size(); ++i) {
             circuit_.add_instruction(
                 Measure{
-                    core::QubitIndex{ static_cast<std::size_t>(qubit_indices[i]->value) }
+                    core::QubitIndex{ static_cast<std::size_t>(qubit_indices[i]->value) },
+                    core::BitIndex{ static_cast<std::size_t>(bit_indices[i]->value) }
                 },
                 controlBits);
         }

--- a/src/qx/InstructionExecutor.cpp
+++ b/src/qx/InstructionExecutor.cpp
@@ -9,7 +9,7 @@ InstructionExecutor::InstructionExecutor(core::QuantumState &s)
 {}
 
 void InstructionExecutor::operator()(Measure const &m) {
-    quantumState.measure(m.qubitIndex, &random::randomZeroOneDouble);
+    quantumState.measure(m.qubitIndex, m.bitIndex, &random::randomZeroOneDouble);
 }
 
 void InstructionExecutor::operator()(MeasurementRegisterOperation const &op) {

--- a/src/qx/OperandsHelper.cpp
+++ b/src/qx/OperandsHelper.cpp
@@ -15,25 +15,38 @@ OperandsHelper::OperandsHelper(const V3Instruction &instruction, const RegisterM
 
 [[nodiscard]] V3Many<V3ConstInt> OperandsHelper::get_register_operand(int id) const {
     if (auto variable_ref = instruction_.operands[id]->as_variable_ref()) {
-        if (!is_qubit_variable(*variable_ref->variable)) {
+        auto ret = V3Many<V3ConstInt>{};
+        if (is_qubit_variable(*variable_ref->variable)) {
+            auto qubit_range = register_manager_.get_qubit_range(variable_ref->variable->name);
+            ret.get_vec().resize(qubit_range.size);
+            std::generate_n(ret.get_vec().begin(), qubit_range.size, [qubit_range, i=0]() mutable {
+                return v3_tree::make<V3ConstInt>(static_cast<v3_primitives::Int>(qubit_range.first + i++));
+            });
+        } else if (is_bit_variable(*variable_ref->variable)) {
+            auto bit_range = register_manager_.get_bit_range(variable_ref->variable->name);
+            ret.get_vec().resize(bit_range.size);
+            std::generate_n(ret.get_vec().begin(), bit_range.size, [bit_range, i=0]() mutable {
+                return v3_tree::make<V3ConstInt>(static_cast<v3_primitives::Int>(bit_range.first + i++));
+            });
+       } else {
             return {};
         }
-        auto qubit_range = register_manager_.get_qubit_range(variable_ref->variable->name);
-        auto ret = V3Many<V3ConstInt>{};
-        ret.get_vec().resize(qubit_range.size);
-        std::generate_n(ret.get_vec().begin(), qubit_range.size, [qubit_range, i=0]() mutable {
-            return v3_tree::make<V3ConstInt>(static_cast<v3_primitives::Int>(qubit_range.first + i++));
-        });
         return ret;
     } else if (auto index_ref = instruction_.operands[id]->as_index_ref()) {
-        if (!is_qubit_variable(*index_ref->variable)) {
+        auto ret = index_ref->indices;
+        if (is_qubit_variable(*index_ref->variable)) {
+            auto qubit_range = register_manager_.get_qubit_range(index_ref->variable->name);
+            std::for_each(ret.get_vec().begin(), ret.get_vec().end(), [qubit_range](const auto &index) {
+                index->value += qubit_range.first;
+            });
+        } else if (is_bit_variable(*index_ref->variable)) {
+            auto bit_range = register_manager_.get_bit_range(index_ref->variable->name);
+            std::for_each(ret.get_vec().begin(), ret.get_vec().end(), [bit_range](const auto &index) {
+                index->value += bit_range.first;
+            });
+        } else {
             return {};
         }
-        auto qubit_range = register_manager_.get_qubit_range(index_ref->variable->name);
-        auto ret = index_ref->indices;
-        std::for_each(ret.get_vec().begin(), ret.get_vec().end(), [qubit_range](const auto &index) {
-            index->value += qubit_range.first;
-        });
         return ret;
     }
     assert(false && "operand is neither a variable reference nor an index reference");

--- a/src/qx/QuantumState.cpp
+++ b/src/qx/QuantumState.cpp
@@ -13,29 +13,41 @@ void QuantumState::checkQuantumState() {
         throw QuantumStateError{ fmt::format("number of qubits exceeds maximum allowed: {} > {}", numberOfQubits,
                                              config::MAX_QUBIT_NUMBER) };
     }
+    if (numberOfBits > config::MAX_BIT_NUMBER) {
+        throw QuantumStateError{ fmt::format("number of bits exceeds maximum allowed: {} > {}", numberOfBits,
+                                             config::MAX_BIT_NUMBER) };
+    }
     if (not isNormalized()) {
         throw QuantumStateError{ "quantum state is not normalized" };
     }
 }
 
-QuantumState::QuantumState(std::size_t qubit_register_size)
+QuantumState::QuantumState(std::size_t qubit_register_size, std::size_t bit_register_size)
     : numberOfQubits{ qubit_register_size }
-    , data{ static_cast<size_t>(1) << numberOfQubits } {
+    , numberOfBits{ bit_register_size }
+    , data{ static_cast<size_t>(1) << numberOfQubits }
+    , bitMeasurementRegister{ numberOfBits } {
 
     data[BasisVector{}] = SparseComplex{ 1. };  // start initialized in state 00...000
     checkQuantumState();
 }
 
-QuantumState::QuantumState(std::size_t qubit_register_size,
+QuantumState::QuantumState(std::size_t qubit_register_size, std::size_t bit_register_size,
                            std::initializer_list<std::pair<std::string, std::complex<double>>> values)
     : numberOfQubits{ qubit_register_size }
-    , data{ static_cast<size_t>(1) << numberOfQubits, values } {
+    , numberOfBits{ bit_register_size }
+    , data{ static_cast<size_t>(1) << numberOfQubits, values }
+    , bitMeasurementRegister{ numberOfBits } {
 
     checkQuantumState();
 }
 
 [[nodiscard]] std::size_t QuantumState::getNumberOfQubits() const {
     return numberOfQubits;
+}
+
+[[nodiscard]] std::size_t QuantumState::getNumberOfBits() const {
+    return numberOfBits;
 }
 
 [[nodiscard]] bool QuantumState::isNormalized() {
@@ -46,10 +58,15 @@ void QuantumState::reset() {
     data.clear();
     data[BasisVector{}] = SparseComplex{ 1. };  // start initialized in state 00...000
     measurementRegister.reset();
+    bitMeasurementRegister.reset();
 }
 
 [[nodiscard]] const BasisVector& QuantumState::getMeasurementRegister() const {
     return measurementRegister;
+}
+
+[[nodiscard]] const BitMeasurementRegister& QuantumState::getBitMeasurementRegister() const {
+    return bitMeasurementRegister;
 }
 
 [[nodiscard]] double QuantumState::getProbabilityOfMeasuringOne(QubitIndex qubitIndex) {

--- a/src/qx/RegisterManager.cpp
+++ b/src/qx/RegisterManager.cpp
@@ -15,41 +15,138 @@ RegisterManagerError::RegisterManagerError(const std::string &message)
     : SimulationError{ message }
 {}
 
-RegisterManager::RegisterManager(const V3OneProgram &program) {
-    auto &&qubit_variables = program->variables.get_vec()
-        | ranges::views::filter([&](const V3OneVariable &variable) { return is_qubit_variable(*variable); });
-    auto &&qubit_variable_sizes = qubit_variables
+Register::Register(const V3OneProgram &program, auto &&is_of_type, std::size_t max_register_size) {
+    auto &&variables = program->variables.get_vec()
+       | ranges::views::filter([&](const V3OneVariable &variable) { return is_of_type(*variable); });
+    auto &&variable_sizes = variables
         | ranges::views::transform([](const V3OneVariable &variable) { return v3_types::size_of(variable->typ); });
-    qubit_register_size_ = ranges::accumulate(qubit_variable_sizes, size_t{});
+    register_size_ = ranges::accumulate(variable_sizes, size_t{});
 
-    if (qubit_register_size_ > config::MAX_QUBIT_NUMBER) {
-        throw RegisterManagerError{ "Cannot run that many qubits in this version of QX-simulator" };
+    if (register_size_ > max_register_size) {
+        throw RegisterManagerError{ fmt::format("{}", register_size_) };
     }
 
-    variable_name_to_qubit_range_.reserve(qubit_register_size_);
-    qubit_index_to_variable_name_.resize(qubit_register_size_);
+    variable_name_to_range_.reserve(register_size_);
+    index_to_variable_name_.resize(register_size_);
 
-    auto current_qubit_index = size_t{};
-    for (auto &&variable: qubit_variables) {
+    auto current_index = size_t{};
+    for (auto &&variable: variables) {
         const auto &variable_size = static_cast<size_t>(cqasm::v3x::types::size_of(variable->typ));
-        variable_name_to_qubit_range_[variable->name] = QubitRange{ current_qubit_index, variable_size };
-        std::fill(qubit_index_to_variable_name_.begin() + static_cast<long>(current_qubit_index),
-                  qubit_index_to_variable_name_.begin() + static_cast<long>(current_qubit_index + variable_size),
+        variable_name_to_range_[variable->name] = Range{ current_index, variable_size };
+        std::fill(index_to_variable_name_.begin() + static_cast<long>(current_index),
+                  index_to_variable_name_.begin() + static_cast<long>(current_index + variable_size),
                   variable->name);
-        current_qubit_index += variable_size;
+        current_index += variable_size;
     };
 }
 
+Register::~Register() = default;
+
+[[nodiscard]] std::size_t Register::size() const {
+    return register_size_;
+}
+
+[[nodiscard]] Range Register::at(const VariableName &name) const {
+    return variable_name_to_range_.at(name);
+}
+
+[[nodiscard]] Index Register::at(const VariableName &name, const std::optional<Index> &subIndex) const {
+    auto range = variable_name_to_range_.at(name);
+    return range.first + subIndex.value_or(0);
+}
+
+[[nodiscard]] VariableName Register::at(const std::size_t &index) const {
+    return index_to_variable_name_.at(index);
+}
+
+[[nodiscard]] std::string Register::toString() const {
+    auto entries = ranges::accumulate(variable_name_to_range_, std::string{},
+        [first=true](auto total, auto const& kv) mutable {
+            auto const& [variableName, range] = kv;
+            total += fmt::format("{}{}: {}", first ? "" : ", ", variableName, range);
+            first = false;
+            return total;
+    });
+    return fmt::format("{{ {0} }}", entries);
+}
+
+QubitRegister::QubitRegister(const V3OneProgram &program) try
+    : Register(program, is_qubit_variable, config::MAX_QUBIT_NUMBER) {
+} catch (const RegisterManagerError &e) {
+    throw RegisterManagerError{ fmt::format("qubit register size exceeds maximum allowed: {} > {}",
+                                            e.what(), config::MAX_QUBIT_NUMBER) };
+}
+
+QubitRegister::~QubitRegister() = default;
+
+BitRegister::BitRegister(const V3OneProgram &program) try
+    : Register(program, is_bit_variable, config::MAX_BIT_NUMBER) {
+} catch (const RegisterManagerError &e) {
+    throw RegisterManagerError{ fmt::format("bit register size exceeds maximum allowed: {} > {}",
+                                            e.what(), config::MAX_BIT_NUMBER) };
+}
+
+BitRegister::~BitRegister() = default;
+
+RegisterManager::RegisterManager(const V3OneProgram &program)
+    : qubit_register_{ program }
+    , bit_register_{ program }
+{}
+
 [[nodiscard]] std::size_t RegisterManager::get_qubit_register_size() const {
-    return qubit_register_size_;
+    return qubit_register_.size();
 }
 
-[[nodiscard]] QubitRange RegisterManager::get_qubit_range(const VariableName &name) const {
-    return variable_name_to_qubit_range_.at(name);
+[[nodiscard]] std::size_t RegisterManager::get_bit_register_size() const {
+    return bit_register_.size();
 }
 
-[[nodiscard]] VariableName RegisterManager::get_variable_name(std::size_t index) const {
-    return qubit_index_to_variable_name_.at(index);
+[[nodiscard]] Range RegisterManager::get_qubit_range(const VariableName &name) const {
+    return qubit_register_.at(name);
+}
+
+[[nodiscard]] Range RegisterManager::get_bit_range(const VariableName &name) const {
+    return bit_register_.at(name);
+}
+
+[[nodiscard]] Index RegisterManager::get_qubit_index(const VariableName &name,
+                                                     const std::optional<Index> &subIndex) const {
+    return qubit_register_.at(name, subIndex);
+}
+
+[[nodiscard]] Index RegisterManager::get_bit_index(const VariableName &name,
+                                                   const std::optional<Index> &subIndex) const {
+    return bit_register_.at(name, subIndex);
+}
+
+[[nodiscard]] VariableName RegisterManager::get_qubit_variable_name(const std::size_t &index) const {
+    return qubit_register_.at(index);
+}
+
+[[nodiscard]] VariableName RegisterManager::get_bit_variable_name(const std::size_t &index) const {
+    return bit_register_.at(index);
+}
+
+[[nodiscard]] QubitRegister const& RegisterManager::get_qubit_register() const {
+    return qubit_register_;
+}
+
+[[nodiscard]] BitRegister const& RegisterManager::get_bit_register() const {
+    return bit_register_;
+}
+
+std::ostream& operator<<(std::ostream& os, Range const& range) {
+    return os << fmt::format("[{}{}]",
+                             range.first,
+                             range.size == 1 ? "" : fmt::format("..{}", range.first + range.size - 1));
+}
+
+std::ostream& operator<<(std::ostream& os, QubitRegister const& qubitRegister) {
+    return os << qubitRegister.toString();
+}
+
+std::ostream& operator<<(std::ostream& os, BitRegister const& bitRegister) {
+    return os << bitRegister.toString();
 }
 
 }  // namespace qx

--- a/src/qx/SimulationResult.cpp
+++ b/src/qx/SimulationResult.cpp
@@ -9,10 +9,25 @@
 
 namespace qx {
 
-SimulationResult::SimulationResult(std::uint64_t requestedShots, std::uint64_t doneShots)
+SimulationResult::SimulationResult(std::uint64_t requestedShots, std::uint64_t doneShots,
+                                   RegisterManager const& registerManager)
     : shotsRequested{ requestedShots }
     , shotsDone{ doneShots }
+    , qubitRegister{ registerManager.get_qubit_register() }
+    , bitRegister{ registerManager.get_bit_register() }
 {}
+
+std::uint8_t SimulationResult::getQubitState(state_string_t const& stateString, std::string const& qubitVariableName,
+                                             std::optional<Index> subIndex) {
+    auto index = qubitRegister.at(qubitVariableName, subIndex);
+    return static_cast<std::uint8_t>(stateString[stateString.size() - index - 1] - '0');
+}
+
+std::uint8_t SimulationResult::getBitMeasurement(state_string_t const& stateString, std::string const& bitVariableName,
+                                                 std::optional<Index> subIndex) {
+    auto index = bitRegister.at(bitVariableName, subIndex);
+    return static_cast<std::uint8_t>(stateString[stateString.size() - index - 1] - '0');
+}
 
 std::ostream &operator<<(std::ostream &os, const SimulationResult &simulationResult) {
     fmt::print(os, "State:\n");
@@ -33,6 +48,17 @@ std::ostream &operator<<(std::ostream &os, const SimulationResult &simulationRes
                    simulationResult.shotsDone,
                    static_cast<double>(measurement.count) / static_cast<double>(simulationResult.shotsDone));
     }
+    fmt::print(os, "Bit measurements:\n");
+    for (auto const &bitMeasurement : simulationResult.bitMeasurements) {
+        fmt::print(os, "\t{1}  {2}/{3}  (count/shots % = {4:.{0}f})\n",
+                   config::OUTPUT_DECIMALS,
+                   bitMeasurement.state,
+                   bitMeasurement.count,
+                   simulationResult.shotsDone,
+                   static_cast<double>(bitMeasurement.count) / static_cast<double>(simulationResult.shotsDone));
+    }
+    fmt::print(os, "Qubit register:\n\t{}\n", simulationResult.qubitRegister);
+    fmt::print(os, "Bit register:\n\t{}", simulationResult.bitRegister);
     return os;
 }
 
@@ -47,10 +73,17 @@ void SimulationResultAccumulator::appendMeasurement(core::BasisVector const& mea
     measurementsCount++;
 }
 
-SimulationResult SimulationResultAccumulator::getSimulationResult() {
+void SimulationResultAccumulator::appendBitMeasurement(core::BitMeasurementRegister const& bitMeasurement) {
+    assert(bitMeasurements.size() < (static_cast<size_t>(1) << state.getNumberOfQubits()));
+    auto bitMeasuredStateString{ fmt::format("{}", bitMeasurement) };
+    bitMeasurements[bitMeasuredStateString]++;
+    bitMeasurementsCount++;
+}
+
+SimulationResult SimulationResultAccumulator::getSimulationResult(RegisterManager const& registerManager) {
     assert(measurementsCount > 0);
 
-    SimulationResult simulationResult{ measurementsCount, measurementsCount };
+    SimulationResult simulationResult{ measurementsCount, measurementsCount, registerManager };
 
     forAllNonZeroStates(
         [this, &simulationResult](core::BasisVector const& superposedState, core::SparseComplex const& sparseComplex) {
@@ -63,6 +96,9 @@ SimulationResult SimulationResultAccumulator::getSimulationResult() {
 
     for (auto const& [stateString, count] : measurements) {
         simulationResult.measurements.push_back(Measurement{ stateString, count });
+    }
+    for (auto const& [stateString, count] : bitMeasurements) {
+        simulationResult.bitMeasurements.push_back(Measurement{ stateString, count });
     }
 
     return simulationResult;

--- a/src/qx/Simulator.cpp
+++ b/src/qx/Simulator.cpp
@@ -67,7 +67,10 @@ execute(
 
     try {
         auto register_manager = RegisterManager{ program };
-        auto quantumState = core::QuantumState{ register_manager.get_qubit_register_size() };
+        auto quantumState = core::QuantumState{
+            register_manager.get_qubit_register_size(),
+            register_manager.get_bit_register_size()
+        };
         auto circuit = Circuit{ program, register_manager };
         auto simulationResultAccumulator = SimulationResultAccumulator{ quantumState };
 
@@ -75,9 +78,10 @@ execute(
             quantumState.reset();
             circuit.execute(quantumState, std::monostate{});
             simulationResultAccumulator.appendMeasurement(quantumState.getMeasurementRegister());
+            simulationResultAccumulator.appendBitMeasurement(quantumState.getBitMeasurementRegister());
         }
 
-        return simulationResultAccumulator.getSimulationResult();
+        return simulationResultAccumulator.getSimulationResult(register_manager);
     } catch (const SimulationError &err) {
         return err;
     }

--- a/src/qx/V3xLibqasmInterface.cpp
+++ b/src/qx/V3xLibqasmInterface.cpp
@@ -7,4 +7,8 @@ bool is_qubit_variable(const V3Variable &variable) {
     return variable.typ->as_qubit() || variable.typ->as_qubit_array();
 }
 
+bool is_bit_variable(const V3Variable &variable) {
+    return variable.typ->as_bit() || variable.typ->as_bit_array();
+}
+
 }  // namespace qx

--- a/test/ErrorModelsTest.cpp
+++ b/test/ErrorModelsTest.cpp
@@ -27,7 +27,7 @@ protected:
     }
 
 private:
-    core::QuantumState state{ 3 }; // Using a mock or a TestQuantumState would be beneficial here.
+    core::QuantumState state{ 3, 3 }; // Using a mock or a TestQuantumState would be beneficial here.
 };
 
 TEST_F(ErrorModelsTest, depolarizing_channel__probability_1) {

--- a/test/IntegrationTest.cpp
+++ b/test/IntegrationTest.cpp
@@ -214,4 +214,30 @@ b1 = measure q1
     EXPECT_LT(std::abs(static_cast<long long>(iterations/2 - actual.measurements[1].count)), error);
 }
 
+TEST_F(IntegrationTest, bit_measurement_register) {
+    std::size_t iterations = 10'000;
+    auto cqasm = R"(
+version 3.0
+
+qubit[2] qq
+X qq[0]
+bit[2] bb
+bb[0] = measure qq[0]
+
+qubit q
+H q
+CNOT q, qq[0]
+bit b
+b = measure qq[0]
+)";
+    auto actual = runFromString(cqasm, iterations);
+
+    auto error = static_cast<std::uint64_t>(static_cast<double>(iterations)/2 * 0.05);
+    EXPECT_EQ(actual.bitMeasurements.size(), 2);
+    for (auto const& bitMeasurement : actual.bitMeasurements) {
+        EXPECT_EQ(actual.getBitMeasurement(bitMeasurement.state, "bb", 0), 1);
+        EXPECT_LT(std::abs(static_cast<long long>(iterations/2 - bitMeasurement.count)), error);
+    }
+}
+
 } // namespace qx

--- a/test/QuantumStateTest.cpp
+++ b/test/QuantumStateTest.cpp
@@ -32,7 +32,7 @@ public:
 };
 
 TEST_F(QuantumStateTest, apply_identity) {
-    QuantumState victim{ 3 };
+    QuantumState victim{ 3, 3 };
 
     EXPECT_EQ(victim.getNumberOfQubits(), 3);
     checkEq(victim, {1, 0, 0, 0, 0, 0, 0, 0});
@@ -44,7 +44,7 @@ TEST_F(QuantumStateTest, apply_identity) {
 }
 
 TEST_F(QuantumStateTest, apply_hadamard) {
-    QuantumState victim{ 3 };
+    QuantumState victim{ 3, 3 };
 
     EXPECT_EQ(victim.getNumberOfQubits(), 3);
     checkEq(victim, {1, 0, 0, 0, 0, 0, 0, 0});
@@ -58,31 +58,31 @@ TEST_F(QuantumStateTest, apply_hadamard) {
 }
 
 TEST_F(QuantumStateTest, apply_cnot) {
-    QuantumState victim{ 2, {{"10", 0.123}, {"11", std::sqrt(1 - std::pow(0.123, 2))}} };
+    QuantumState victim{ 2, 2, {{"10", 0.123}, {"11", std::sqrt(1 - std::pow(0.123, 2))}} };
     checkEq(victim, {0, 0, 0.123, std::sqrt(1 - std::pow(0.123, 2))});
     victim.apply<2>(gates::CNOT, std::array<QubitIndex, 2>{QubitIndex{1}, QubitIndex{0}});
     checkEq(victim, {0, 0, std::sqrt(1 - std::pow(0.123, 2)), 0.123});
 }
 
 TEST_F(QuantumStateTest, measure_on_non_superposed_state) {
-    QuantumState victim{ 2, {{"10", 0.123}, {"11", std::sqrt(1 - std::pow(0.123, 2))}} };
-    victim.measure(QubitIndex{1}, []() { return 0.9485; });
+    QuantumState victim{ 2, 2, {{"10", 0.123}, {"11", std::sqrt(1 - std::pow(0.123, 2))}} };
+    victim.measure(QubitIndex{1}, BitIndex{1}, []() { return 0.9485; });
     checkEq(victim, {0, 0, 0.123, std::sqrt(1 - std::pow(0.123, 2))});
-    victim.measure(QubitIndex{1}, []() { return 0.045621; });
+    victim.measure(QubitIndex{1}, BitIndex{0}, []() { return 0.045621; });
     checkEq(victim, {0, 0, 0.123, std::sqrt(1 - std::pow(0.123, 2))});
     EXPECT_EQ(victim.getMeasurementRegister(), BasisVector("10"));
 }
 
 TEST_F(QuantumStateTest, measure_on_superposed_state__case_0) {
-    QuantumState victim{ 2, {{"10", 0.123}, {"11", std::sqrt(1 - std::pow(0.123, 2))}} };
-    victim.measure(QubitIndex{0}, []() { return 0.994; });
+    QuantumState victim{ 2, 2, {{"10", 0.123}, {"11", std::sqrt(1 - std::pow(0.123, 2))}} };
+    victim.measure(QubitIndex{0}, BitIndex{0}, []() { return 0.994; });
     checkEq(victim, {0, 0, 1, 0});
     EXPECT_EQ(victim.getMeasurementRegister(), BasisVector("00"));
 }
 
 TEST_F(QuantumStateTest, measure_on_superposed_state__case_1) {
-    QuantumState victim{ 2, {{"10", 0.123}, {"11", std::sqrt(1 - std::pow(0.123, 2))}} };
-    victim.measure(QubitIndex{0}, []() { return 0.254; });
+    QuantumState victim{ 2, 2, {{"10", 0.123}, {"11", std::sqrt(1 - std::pow(0.123, 2))}} };
+    victim.measure(QubitIndex{0}, BitIndex{0}, []() { return 0.254; });
     checkEq(victim, {0, 0, 0, 1});
     EXPECT_EQ(victim.getMeasurementRegister(), BasisVector("01"));
 }


### PR DESCRIPTION
With the introduction of bit (register) variables in the language and in the libqasm parser (mainly due to the introduction of the `measure` intruction with the form `<bit-side> = measure <qubit-side>`), the QX simulator has to be updated to support bit (register) variables.

It turns out that this opens a big discussion (see this [Confluence page](https://qutech-sd.atlassian.net/wiki/spaces/QW/pages/3500277765/Proposal+SimulationResult+format)) because, once you have multiple qubit and bit registers, and you can measure a given qubit to different bit registers, and, basically, you don’t have anymore a 1-to-1 correspondence between qubits and bits -here we should ask ourselves, wait, what qubits anyway? because once you have qubit (register) variables you don’t have either a single qubit register anymore-, then you cannot simply use a “measurement register” (the same you cannot simply use a “qubit register”). But that discussion is covered by [CQT-139: Formalize the new SimulationResult format](https://qutech-sd.atlassian.net/jira/software/c/projects/CQT/boards/18/backlog?customFilter=37&selectedIssue=CQT-139)

With this [CQT-26: Manage bit (register) variables](https://qutech-sd.atlassian.net/jira/software/c/projects/CQT/boards/18?selectedIssue=CQT-26) we just make QX simulator aware of bit (register) variables.