### PR TITLE
[CQT-130] Take measurement register out of QuantumState

### DIFF
--- a/include/qx/Circuit.hpp
+++ b/include/qx/Circuit.hpp
@@ -18,7 +18,9 @@ public:
     Circuit(V3OneProgram &program, RegisterManager &register_manager);
     [[nodiscard]] RegisterManager& get_register_manager() const;
     void add_instruction(Instruction instruction, ControlBits control_bits);
-    void execute(core::QuantumState &quantumState, core::BasisVector &measurementRegister, error_models::ErrorModel const &errorModel) const;
+    void execute(core::QuantumState &quantumState, core::BasisVector &measurementRegister,
+                 core::BitMeasurementRegister &bitMeasurementRegister,
+                 error_models::ErrorModel const &errorModel) const;
 
 private:
     V3OneProgram program_;

--- a/include/qx/Circuit.hpp
+++ b/include/qx/Circuit.hpp
@@ -18,7 +18,7 @@ public:
     Circuit(V3OneProgram &program, RegisterManager &register_manager);
     [[nodiscard]] RegisterManager& get_register_manager() const;
     void add_instruction(Instruction instruction, ControlBits control_bits);
-    void execute(core::QuantumState &quantumState, error_models::ErrorModel const &errorModel) const;
+    void execute(core::QuantumState &quantumState, core::BasisVector &measurementRegister, error_models::ErrorModel const &errorModel) const;
 
 private:
     V3OneProgram program_;

--- a/include/qx/InstructionExecutor.hpp
+++ b/include/qx/InstructionExecutor.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "qx/Core.hpp"
 #include "qx/Instructions.hpp"
 #include "qx/QuantumState.hpp"
 
@@ -10,18 +11,19 @@ namespace qx{
 
 class InstructionExecutor {
 public:
-    explicit InstructionExecutor(core::QuantumState &s);
+    explicit InstructionExecutor(core::QuantumState &state, core::BasisVector &measurement_register);
 
     void operator()(Measure const &m);
     void operator()(MeasurementRegisterOperation const &op);
 
     template <std::size_t N>
     void operator()(Unitary<N> const &u) {
-        quantumState.apply(u.matrix, u.operands);
+        state_.apply(u.matrix, u.operands);
     }
 
 private:
-    core::QuantumState &quantumState;
+    core::QuantumState &state_;
+    core::BasisVector &measurement_register_;
 };
 
 } // namespace qx

--- a/include/qx/InstructionExecutor.hpp
+++ b/include/qx/InstructionExecutor.hpp
@@ -11,7 +11,8 @@ namespace qx{
 
 class InstructionExecutor {
 public:
-    explicit InstructionExecutor(core::QuantumState &state, core::BasisVector &measurement_register);
+    explicit InstructionExecutor(core::QuantumState &state, core::BasisVector &measurement_register,
+                                 core::BitMeasurementRegister &bit_measurement_register);
 
     void operator()(Measure const &m);
     void operator()(Reset const &m);
@@ -26,6 +27,7 @@ public:
 private:
     core::QuantumState &state_;
     core::BasisVector &measurement_register_;
+    core::BitMeasurementRegister &bit_measurement_register_;
 };
 
 } // namespace qx

--- a/include/qx/QuantumState.hpp
+++ b/include/qx/QuantumState.hpp
@@ -53,7 +53,6 @@ class QuantumState {
     void checkQuantumState();
 
     void resetData();
-    void resetMeasurementRegister();
 
 public:
     QuantumState(std::size_t qubit_register_size, std::size_t bit_register_size);
@@ -97,7 +96,7 @@ public:
     // measuredState will be true if we measured a 1, or false if we measured a 0
     template <typename F>
     void applyMeasure(QubitIndex qubitIndex, BitIndex bitIndex, F &&randomGenerator,
-                      core::BasisVector &measurementRegister, core::BasisVector &bitMeasurementRegister) {
+                      core::BasisVector &measurementRegister, core::BitMeasurementRegister &bitMeasurementRegister) {
         auto probabilityOfMeasuringOne = getProbabilityOfMeasuringOne(qubitIndex);
         auto measuredState = (randomGenerator() < probabilityOfMeasuringOne);
         updateDataAfterMeasurement(qubitIndex, measuredState, probabilityOfMeasuringOne);

--- a/include/qx/QuantumState.hpp
+++ b/include/qx/QuantumState.hpp
@@ -81,14 +81,13 @@ public:
         data.forEachSorted(f);
     }
 
-    [[nodiscard]] const BasisVector &getMeasurementRegister() const;
     [[nodiscard]] double getProbabilityOfMeasuringOne(QubitIndex qubitIndex);
     [[nodiscard]] double getProbabilityOfMeasuringZero(QubitIndex qubitIndex);
     void collapseQubitState(QubitIndex qubitIndex, bool measuredState, double probabilityOfMeasuringOne);
 
     // measuredState will be true if we measured a 1, or false if we measured a 0
     template <typename F>
-    void measure(QubitIndex qubitIndex, F &&randomGenerator) {
+    void measure(QubitIndex qubitIndex, F &&randomGenerator, core::BasisVector &measurementRegister) {
         auto probabilityOfMeasuringOne = getProbabilityOfMeasuringOne(qubitIndex);
         auto measuredState = (randomGenerator() < probabilityOfMeasuringOne);
         collapseQubitState(qubitIndex, measuredState, probabilityOfMeasuringOne);
@@ -98,7 +97,6 @@ public:
 private:
     std::size_t numberOfQubits = 1;
     SparseArray data;
-    BasisVector measurementRegister{};
 };
 
 }  // namespace qx::core

--- a/src/qx/Circuit.cpp
+++ b/src/qx/Circuit.cpp
@@ -28,8 +28,10 @@ void Circuit::add_instruction(Instruction instruction, ControlBits control_bits)
     controlled_instructions_.emplace_back(std::move(instruction), std::move(control_bits));
 }
 
-void Circuit::execute(core::QuantumState &quantumState, core::BasisVector &measurementRegister, error_models::ErrorModel const &errorModel) const {
-    InstructionExecutor instruction_executor{ quantumState, measurementRegister };
+void Circuit::execute(core::QuantumState &quantumState, core::BasisVector &measurementRegister,
+                      core::BitMeasurementRegister &bitMeasurementRegister,
+                      error_models::ErrorModel const &errorModel) const {
+    InstructionExecutor instruction_executor{ quantumState, measurementRegister, bitMeasurementRegister };
     for (auto const &controlled_instruction: controlled_instructions_) {
         if (auto *depolarizing_channel = std::get_if<error_models::DepolarizingChannel>(&errorModel)) {
             depolarizing_channel->addError(quantumState);

--- a/src/qx/InstructionExecutor.cpp
+++ b/src/qx/InstructionExecutor.cpp
@@ -4,13 +4,16 @@
 
 namespace qx {
 
-InstructionExecutor::InstructionExecutor(core::QuantumState &state, core::BasisVector &measurement_register)
+InstructionExecutor::InstructionExecutor(core::QuantumState &state, core::BasisVector &measurement_register,
+                                         core::BitMeasurementRegister &bit_measurement_register)
     : state_{ state }
     , measurement_register_{ measurement_register }
+    , bit_measurement_register_{ bit_measurement_register }
 {}
 
 void InstructionExecutor::operator()(Measure const &m) {
-    state_.applyMeasure(m.qubitIndex, m.bitIndex, &random::randomZeroOneDouble, measurement_register);
+    state_.applyMeasure(m.qubitIndex, m.bitIndex, &random::randomZeroOneDouble, measurement_register_,
+                        bit_measurement_register_);
 }
 
 void InstructionExecutor::operator()(Reset const &r) {

--- a/src/qx/InstructionExecutor.cpp
+++ b/src/qx/InstructionExecutor.cpp
@@ -4,16 +4,17 @@
 
 namespace qx {
 
-InstructionExecutor::InstructionExecutor(core::QuantumState &s)
-    : quantumState(s)
+InstructionExecutor::InstructionExecutor(core::QuantumState &state, core::BasisVector &measurement_register)
+    : state_{ state }
+    , measurement_register_{ measurement_register }
 {}
 
 void InstructionExecutor::operator()(Measure const &m) {
-    quantumState.measure(m.qubitIndex, &random::randomZeroOneDouble);
+    state_.measure(m.qubitIndex, &random::randomZeroOneDouble, measurement_register_);
 }
 
 void InstructionExecutor::operator()(MeasurementRegisterOperation const &op) {
-    op.operation(quantumState.getMeasurementRegister());
+    op.operation(measurement_register_);
 }
 
 }  // namespace qx

--- a/src/qx/QuantumState.cpp
+++ b/src/qx/QuantumState.cpp
@@ -45,11 +45,6 @@ QuantumState::QuantumState(std::size_t qubit_register_size,
 void QuantumState::reset() {
     data.clear();
     data[BasisVector{}] = SparseComplex{ 1. };  // start initialized in state 00...000
-    measurementRegister.reset();
-}
-
-[[nodiscard]] const BasisVector& QuantumState::getMeasurementRegister() const {
-    return measurementRegister;
 }
 
 [[nodiscard]] double QuantumState::getProbabilityOfMeasuringOne(QubitIndex qubitIndex) {

--- a/src/qx/Simulator.cpp
+++ b/src/qx/Simulator.cpp
@@ -67,14 +67,15 @@ execute(
 
     try {
         auto register_manager = RegisterManager{ program };
-        auto quantumState = core::QuantumState{ register_manager.get_qubit_register_size() };
+        auto quantum_state = core::QuantumState{ register_manager.get_qubit_register_size() };
         auto circuit = Circuit{ program, register_manager };
-        auto simulationResultAccumulator = SimulationResultAccumulator{ quantumState };
+        auto simulationResultAccumulator = SimulationResultAccumulator{ quantum_state };
 
         while (iterations--) {
-            quantumState.reset();
-            circuit.execute(quantumState, std::monostate{});
-            simulationResultAccumulator.appendMeasurement(quantumState.getMeasurementRegister());
+            quantum_state.reset();
+            auto measurement_register = core::BasisVector{};
+            circuit.execute(quantum_state, measurement_register, std::monostate{});
+            simulationResultAccumulator.appendMeasurement(measurement_register);
         }
 
         return simulationResultAccumulator.getSimulationResult();

--- a/src/qx/Simulator.cpp
+++ b/src/qx/Simulator.cpp
@@ -71,13 +71,15 @@ execute(
             register_manager.get_qubit_register_size(),
             register_manager.get_bit_register_size()
         };
+        auto measurement_register = core::BasisVector{};
+        auto bit_measurement_register = core::BitMeasurementRegister{ register_manager.get_bit_register_size() };
         auto circuit = Circuit{ program, register_manager };
         auto simulationResultAccumulator = SimulationResultAccumulator{ quantum_state };
 
         while (iterations--) {
             quantum_state.reset();
-            auto measurement_register = core::BasisVector{};
-            auto bit_measurement_register = core::BasisVector{};
+            measurement_register.reset();
+            bit_measurement_register.reset();
             circuit.execute(quantum_state, measurement_register, bit_measurement_register, std::monostate{});
             simulationResultAccumulator.appendMeasurement(measurement_register);
             simulationResultAccumulator.appendBitMeasurement(bit_measurement_register);

--- a/test/QuantumStateTest.cpp
+++ b/test/QuantumStateTest.cpp
@@ -65,26 +65,29 @@ TEST_F(QuantumStateTest, apply_cnot) {
 }
 
 TEST_F(QuantumStateTest, measure_on_non_superposed_state) {
+    auto measurement_register = core::BasisVector{};
     QuantumState victim{ 2, {{"10", 0.123}, {"11", std::sqrt(1 - std::pow(0.123, 2))}} };
-    victim.measure(QubitIndex{1}, []() { return 0.9485; });
+    victim.measure(QubitIndex{1}, []() { return 0.9485; }, measurement_register);
     checkEq(victim, {0, 0, 0.123, std::sqrt(1 - std::pow(0.123, 2))});
-    victim.measure(QubitIndex{1}, []() { return 0.045621; });
+    victim.measure(QubitIndex{1}, []() { return 0.045621; }, measurement_register);
     checkEq(victim, {0, 0, 0.123, std::sqrt(1 - std::pow(0.123, 2))});
-    EXPECT_EQ(victim.getMeasurementRegister(), BasisVector("10"));
+    EXPECT_EQ(measurement_register, BasisVector{ "10" });
 }
 
 TEST_F(QuantumStateTest, measure_on_superposed_state__case_0) {
+    auto measurement_register = core::BasisVector{};
     QuantumState victim{ 2, {{"10", 0.123}, {"11", std::sqrt(1 - std::pow(0.123, 2))}} };
-    victim.measure(QubitIndex{0}, []() { return 0.994; });
+    victim.measure(QubitIndex{0}, []() { return 0.994; }, measurement_register);
     checkEq(victim, {0, 0, 1, 0});
-    EXPECT_EQ(victim.getMeasurementRegister(), BasisVector("00"));
+    EXPECT_EQ(measurement_register, BasisVector("00"));
 }
 
 TEST_F(QuantumStateTest, measure_on_superposed_state__case_1) {
+    auto measurement_register = core::BasisVector{};
     QuantumState victim{ 2, {{"10", 0.123}, {"11", std::sqrt(1 - std::pow(0.123, 2))}} };
-    victim.measure(QubitIndex{0}, []() { return 0.254; });
+    victim.measure(QubitIndex{0}, []() { return 0.254; }, measurement_register);
     checkEq(victim, {0, 0, 0, 1});
-    EXPECT_EQ(victim.getMeasurementRegister(), BasisVector("01"));
+    EXPECT_EQ(measurement_register, BasisVector("01"));
 }
 
 } // namespace qx::core

--- a/test/QuantumStateTest.cpp
+++ b/test/QuantumStateTest.cpp
@@ -57,10 +57,13 @@ TEST_F(QuantumStateTest, apply_cnot) {
 
 TEST_F(QuantumStateTest, measure_on_non_superposed_state) {
     auto measurement_register = core::BasisVector{};
+    auto bit_measurement_register = core::BitMeasurementRegister{ 2 };
     QuantumState victim{ 2, 2, {{"10", 0.123}, {"11", std::sqrt(1 - std::pow(0.123, 2))}} };
-    victim.applyMeasure(QubitIndex{ 1 }, BitIndex{ 1 }, []() { return 0.9485; }, measurement_register, bit_measurement_register);
+    victim.applyMeasure(QubitIndex{ 1 }, BitIndex{ 1 }, []() { return 0.9485; }, measurement_register,
+                        bit_measurement_register);
     checkEq(victim, {0, 0, 0.123, std::sqrt(1 - std::pow(0.123, 2))});
-    victim.applyMeasure(QubitIndex{ 1 }, BitIndex{ 0 }, []() { return 0.045621; }, measurement_register, bit_measurement_register);
+    victim.applyMeasure(QubitIndex{ 1 }, BitIndex{ 0 }, []() { return 0.045621; }, measurement_register,
+                        bit_measurement_register);
     checkEq(victim, {0, 0, 0.123, std::sqrt(1 - std::pow(0.123, 2))});
     EXPECT_EQ(measurement_register, BasisVector{ "10" });
 }
@@ -69,38 +72,36 @@ TEST_F(QuantumStateTest, measure_on_superposed_state__measured_state_is_0) {
     // The random generator function returns a number bigger than the probability of measuring 1, so we measure 0
     // 0.994 > 1 - 0.123^2
     auto measurement_register = core::BasisVector{};
-    auto bit_measurement_register = core::BasisVector{};
+    auto bit_measurement_register = core::BitMeasurementRegister{ 2 };
     QuantumState victim{ 2, 2, {{"10", 0.123}, {"11", std::sqrt(1 - std::pow(0.123, 2))}} };
-    victim.applyMeasure(QubitIndex{ 0 }, BitIndex{ 0 }, []() { return 0.994; }, measurement_register, bit_measurement_register);
+    victim.applyMeasure(QubitIndex{ 0 }, BitIndex{ 0 }, []() { return 0.994; }, measurement_register,
+                        bit_measurement_register);
     checkEq(victim, {0, 0, 1, 0});  // 10
-    EXPECT_EQ(measurement_register, BasisVector("00"));
+    EXPECT_EQ(measurement_register, BasisVector{ "00" });
 }
 
 TEST_F(QuantumStateTest, measure_on_superposed_state__measured_state_is_1) {
     // The random generator function returns a number smaller than the probability of measuring 1, so we measure 1
     // 0.254 < 1 - 0.123^2
     auto measurement_register = core::BasisVector{};
-    auto bit_measurement_register = core::BasisVector{};
+    auto bit_measurement_register = core::BitMeasurementRegister{ 2 };
     QuantumState victim{ 2, 2, {{"10", 0.123}, {"11", std::sqrt(1 - std::pow(0.123, 2))}} };
-    victim.applyMeasure(QubitIndex{ 0 }, BitIndex{ 0 }, []() { return 0.254; }, measurement_register, bit_measurement_register);
+    victim.applyMeasure(QubitIndex{ 0 }, BitIndex{ 0 }, []() { return 0.254; }, measurement_register,
+                        bit_measurement_register);
     checkEq(victim, {0, 0, 0, 1});  // 11
-    EXPECT_EQ(measurement_register, BasisVector("01"));
+    EXPECT_EQ(measurement_register, BasisVector{ "01" });
 }
 
 TEST_F(QuantumStateTest, reset) {
-    auto measurement_register = core::BasisVector{};
     QuantumState victim{ 2, 2, {{"00", 0.123}, {"11", std::sqrt(1 - std::pow(0.123, 2))}} };
-    victim.applyReset(QubitIndex{ 0 }, measurement_register);
+    victim.applyReset(QubitIndex{ 0 });
     checkEq(victim, {0.123, 0, std::sqrt(1 - std::pow(0.123, 2)), 0});  // 00 and 10
-    EXPECT_EQ(measurement_register, BasisVector("00"));
 }
 
 TEST_F(QuantumStateTest, reset_all) {
-    auto measurement_register = core::BasisVector{};
     QuantumState victim{ 2, 2, {{"00", 0.123}, {"11", std::sqrt(1 - std::pow(0.123, 2))}} };
-    victim.applyResetAll(measurement_register);
+    victim.applyResetAll();
     checkEq(victim, QuantumState{ 2, 2 }.toVector());
-    EXPECT_EQ(measurement_register, BasisVector("00"));
 }
 
 } // namespace qx::core


### PR DESCRIPTION
While making this refactoring I've noticed there is room for quite some more changes.
So I intend this to be the first of a series of mini refactorings.
However, up to this point, we have what we pretended: taking the measurement register out of the QuantumState.

- Add measurement register to InstructionExecutor.
- Add measurement register to Circuit::execute.
- Add measurement register to QuantumState::measure.
- Rename some variables.