### PR TITLE
[CQT-274] Change `Circuit::execute` to return `SimulationIterationResult`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 
+## [ 0.7.3 ] - [ xxxx-yy-zz ]
+
+### Added
+
+### Changed
+
+- Take measurement register out of `QuantumState`. 
+- Change `Circuit::execute` to return a `SimulationIterationResult`.
+
+### Removed
+
+
 ## [ 0.7.2 ] - [ 2024-11-20 ]
 
 ### Added

--- a/include/qx/Circuit.hpp
+++ b/include/qx/Circuit.hpp
@@ -4,6 +4,7 @@
 #include "qx/ErrorModels.hpp"
 #include "qx/Instructions.hpp"
 #include "qx/RegisterManager.hpp"
+#include "qx/SimulationResult.hpp"
 #include "qx/V3xLibqasmInterface.hpp"
 
 #include <optional>
@@ -18,13 +19,12 @@ public:
     Circuit(V3OneProgram &program, RegisterManager &register_manager);
     [[nodiscard]] RegisterManager& get_register_manager() const;
     void add_instruction(Instruction instruction, ControlBits control_bits);
-    void execute(core::QuantumState &quantumState, core::BasisVector &measurementRegister,
-                 core::BitMeasurementRegister &bitMeasurementRegister,
-                 error_models::ErrorModel const &errorModel) const;
+    [[nodiscard]] SimulationIterationResult execute(error_models::ErrorModel const &errorModel) const;
 
 private:
     V3OneProgram program_;
     RegisterManager &register_manager_;
     std::vector<ControlledInstruction> controlled_instructions_;
 };
+
 }  // namespace qx

--- a/include/qx/InstructionExecutor.hpp
+++ b/include/qx/InstructionExecutor.hpp
@@ -2,7 +2,9 @@
 
 #include "qx/Core.hpp"
 #include "qx/Instructions.hpp"
+#include "qx/RegisterManager.hpp"
 #include "qx/QuantumState.hpp"
+#include "qx/SimulationResult.hpp"
 
 #include <cstddef>  // size_t
 
@@ -11,8 +13,7 @@ namespace qx{
 
 class InstructionExecutor {
 public:
-    explicit InstructionExecutor(core::QuantumState &state, core::BasisVector &measurement_register,
-                                 core::BitMeasurementRegister &bit_measurement_register);
+    explicit InstructionExecutor(RegisterManager &register_manager);
 
     void operator()(Measure const &m);
     void operator()(Reset const &m);
@@ -21,13 +22,13 @@ public:
 
     template <std::size_t N>
     void operator()(Unitary<N> const &u) {
-        state_.apply(u.matrix, u.operands);
+        simulation_iteration_result_.state.apply(u.matrix, u.operands);
     }
 
+    SimulationIterationResult &getSimulationIterationResult();
+
 private:
-    core::QuantumState &state_;
-    core::BasisVector &measurement_register_;
-    core::BitMeasurementRegister &bit_measurement_register_;
+    SimulationIterationResult simulation_iteration_result_;
 };
 
 } // namespace qx

--- a/include/qx/QuantumState.hpp
+++ b/include/qx/QuantumState.hpp
@@ -55,6 +55,7 @@ class QuantumState {
     void resetData();
 
 public:
+    QuantumState();
     QuantumState(std::size_t qubit_register_size, std::size_t bit_register_size);
     QuantumState(std::size_t qubit_register_size, std::size_t bit_register_size,
                  std::initializer_list<std::pair<std::string, std::complex<double>>> values);
@@ -114,8 +115,8 @@ public:
     }
 
 private:
-    std::size_t numberOfQubits = 1;
-    std::size_t numberOfBits = 1;
+    std::size_t numberOfQubits;
+    std::size_t numberOfBits;
     SparseArray data;
 };
 

--- a/include/qx/SimulationResult.hpp
+++ b/include/qx/SimulationResult.hpp
@@ -45,6 +45,15 @@ struct SuperposedState {
 };
 
 
+struct SimulationIterationResult {
+    core::QuantumState state;
+    core::BasisVector measurement_register;
+    core::BitMeasurementRegister bit_measurement_register;
+
+    explicit SimulationIterationResult(RegisterManager const& registerManager);
+};
+
+
 struct SimulationResult {
     using Measurements = std::vector<Measurement>;
     using State = std::vector<SuperposedState>;
@@ -82,7 +91,7 @@ std::ostream &operator<<(std::ostream &os, const SimulationResult &result);
 
 class SimulationResultAccumulator {
 public:
-    explicit SimulationResultAccumulator(core::QuantumState &s);
+    void add(const SimulationIterationResult &simulationIterationResult);
     void appendMeasurement(core::BasisVector const& measurement);
     void appendBitMeasurement(core::BitMeasurementRegister const& bitMeasurement);
     SimulationResult getSimulationResult(RegisterManager const& registerManager);
@@ -95,7 +104,7 @@ private:
         });
     }
 
-    core::QuantumState &state;
+    core::QuantumState state;
     absl::btree_map<state_string_t, count_t> measurements;
     absl::btree_map<state_string_t, count_t> bitMeasurements;
 

--- a/include/qx/Simulator.hpp
+++ b/include/qx/Simulator.hpp
@@ -10,15 +10,13 @@
 
 namespace qx {
 
-std::variant<std::monostate, SimulationResult, SimulationError>
-executeString(
+std::variant<std::monostate, SimulationResult, SimulationError> executeString(
     std::string const &s,
     std::size_t iterations = 1,
     std::optional<std::uint_fast64_t> seed = std::nullopt,
     std::string cqasm_version = "3.0");
 
-std::variant<std::monostate, SimulationResult, SimulationError>
-executeFile(
+std::variant<std::monostate, SimulationResult, SimulationError> executeFile(
     std::string const &filePath,
     std::size_t iterations = 1,
     std::optional<std::uint_fast64_t> seed = std::nullopt,

--- a/src/qx/InstructionExecutor.cpp
+++ b/src/qx/InstructionExecutor.cpp
@@ -4,28 +4,33 @@
 
 namespace qx {
 
-InstructionExecutor::InstructionExecutor(core::QuantumState &state, core::BasisVector &measurement_register,
-                                         core::BitMeasurementRegister &bit_measurement_register)
-    : state_{ state }
-    , measurement_register_{ measurement_register }
-    , bit_measurement_register_{ bit_measurement_register }
+InstructionExecutor::InstructionExecutor(RegisterManager &register_manager)
+    : simulation_iteration_result_{ register_manager }
 {}
 
 void InstructionExecutor::operator()(Measure const &m) {
-    state_.applyMeasure(m.qubitIndex, m.bitIndex, &random::randomZeroOneDouble, measurement_register_,
-                        bit_measurement_register_);
+    simulation_iteration_result_.state.applyMeasure(
+        m.qubitIndex,
+        m.bitIndex,
+        &random::randomZeroOneDouble,
+        simulation_iteration_result_.measurement_register,
+        simulation_iteration_result_.bit_measurement_register);
 }
 
 void InstructionExecutor::operator()(Reset const &r) {
-    state_.applyReset(r.qubitIndex);
+    simulation_iteration_result_.state.applyReset(r.qubitIndex);
 }
 
 void InstructionExecutor::operator()(ResetAll const &/* r */) {
-    state_.applyResetAll();
+    simulation_iteration_result_.state.applyResetAll();
 }
 
 void InstructionExecutor::operator()(MeasurementRegisterOperation const &op) {
-    op.operation(measurement_register_);
+    op.operation(simulation_iteration_result_.measurement_register);
+}
+
+SimulationIterationResult &InstructionExecutor::getSimulationIterationResult() {
+    return simulation_iteration_result_;
 }
 
 }  // namespace qx

--- a/src/qx/QuantumState.cpp
+++ b/src/qx/QuantumState.cpp
@@ -25,6 +25,10 @@ void QuantumState::checkQuantumState() {
     }
 }
 
+QuantumState::QuantumState()
+    : QuantumState{ 1, 1 }
+{}
+
 QuantumState::QuantumState(std::size_t qubit_register_size, std::size_t bit_register_size)
     : numberOfQubits{ qubit_register_size }
     , numberOfBits{ bit_register_size }

--- a/src/qx/SimulationResult.cpp
+++ b/src/qx/SimulationResult.cpp
@@ -9,6 +9,21 @@
 
 namespace qx {
 
+//---------------------------//
+// SimulationIterationResult //
+//---------------------------//
+
+SimulationIterationResult::SimulationIterationResult(RegisterManager const& registerManager)
+    : state{ registerManager.get_qubit_register_size(), registerManager.get_bit_register_size() }
+    , measurement_register{}
+    , bit_measurement_register{ registerManager.get_bit_register_size() }
+{}
+
+
+//------------------//
+// SimulationResult //
+//------------------//
+
 SimulationResult::SimulationResult(std::uint64_t requestedShots, std::uint64_t doneShots,
                                    RegisterManager const& registerManager)
     : shotsRequested{ requestedShots }
@@ -62,9 +77,16 @@ std::ostream &operator<<(std::ostream &os, const SimulationResult &simulationRes
     return os;
 }
 
-SimulationResultAccumulator::SimulationResultAccumulator(core::QuantumState &s)
-    : state(s)
-{}
+
+//-----------------------------//
+// SimulationResultAccumulator //
+//-----------------------------//
+
+void SimulationResultAccumulator::add(SimulationIterationResult const& simulationIterationResult) {
+    state = simulationIterationResult.state;
+    appendMeasurement(simulationIterationResult.measurement_register);
+    appendBitMeasurement(simulationIterationResult.bit_measurement_register);
+}
 
 void SimulationResultAccumulator::appendMeasurement(core::BasisVector const& measurement) {
     assert(measurements.size() < (static_cast<size_t>(1) << state.getNumberOfQubits()));

--- a/src/qx/Simulator.cpp
+++ b/src/qx/Simulator.cpp
@@ -45,8 +45,7 @@ std::variant<V3OneProgram, SimulationError> getV3ProgramOrError(V3AnalysisResult
     return program;
 }
 
-std::variant<std::monostate, SimulationResult, SimulationError>
-execute(
+std::variant<std::monostate, SimulationResult, SimulationError> execute(
     V3AnalysisResult const& analysisResult,
     std::size_t iterations,
     std::optional<std::uint_fast64_t> seed) {
@@ -67,22 +66,11 @@ execute(
 
     try {
         auto register_manager = RegisterManager{ program };
-        auto quantum_state = core::QuantumState{
-            register_manager.get_qubit_register_size(),
-            register_manager.get_bit_register_size()
-        };
-        auto measurement_register = core::BasisVector{};
-        auto bit_measurement_register = core::BitMeasurementRegister{ register_manager.get_bit_register_size() };
         auto circuit = Circuit{ program, register_manager };
-        auto simulationResultAccumulator = SimulationResultAccumulator{ quantum_state };
+        auto simulationResultAccumulator = SimulationResultAccumulator{};
 
         while (iterations--) {
-            quantum_state.reset();
-            measurement_register.reset();
-            bit_measurement_register.reset();
-            circuit.execute(quantum_state, measurement_register, bit_measurement_register, std::monostate{});
-            simulationResultAccumulator.appendMeasurement(measurement_register);
-            simulationResultAccumulator.appendBitMeasurement(bit_measurement_register);
+            simulationResultAccumulator.add(circuit.execute(std::monostate{}));
         }
 
         return simulationResultAccumulator.getSimulationResult(register_manager);
@@ -93,8 +81,7 @@ execute(
 
 }  // namespace
 
-std::variant<std::monostate, SimulationResult, SimulationError>
-executeString(
+std::variant<std::monostate, SimulationResult, SimulationError> executeString(
     std::string const &s,
     std::size_t iterations,
     std::optional<std::uint_fast64_t> seed,


### PR DESCRIPTION
The `SimulationIterationResult` holds:
- a quantum state,
- a measurement register, and
- a bit measurement register.

The `InstructionExecutor` holds a simulation iteration result.

The `execute` function at Simulator.cpp is simplified to:
- accumulating the simulation iteration results of executing a circuit, and then
- returning the final simulation result.