### PR TITLE
[CQT-292] Remove `abseil` dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Implement instructions as a hierarchy.
 - Reimplement `GateConvertor` as a `CircuitBuilder`.
 - Change file, functions, and variable names.
+- Implement `BasisVector` as a `boost::dynamic_bitset<uint32_t>`.
 
 ### Removed
+
+- Remove `abseil` library dependency.
 
 
 ## [ 0.7.2 ] - [ 2024-11-20 ]

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,7 +110,6 @@ set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 # Dependencies                                                                #
 #=============================================================================#
 
-find_package(absl  REQUIRED)
 find_package(Boost REQUIRED)
 find_package(fmt REQUIRED)
 find_package(libqasm REQUIRED)
@@ -203,7 +202,6 @@ endif()
 #=============================================================================#
 
 target_link_libraries(qx PUBLIC
-    absl::flat_hash_map
     fmt::fmt
     libqasm::libqasm
     range-v3::range-v3
@@ -249,7 +247,6 @@ endif()
 message(STATUS
     "[${PROJECT_NAME}] Target include directories:\n"
     "      CMAKE_CURRENT_SOURCE_DIR/include/: ${CMAKE_CURRENT_SOURCE_DIR}/include/\n"
-    "      absl_INCLUDE_DIRS: ${absl_INCLUDE_DIRS}\n"
     "      Boost_INCLUDE_DIRS: ${Boost_INCLUDE_DIRS}\n"
     "      fmt_INCLUDE_DIRS: ${fmt_INCLUDE_DIRS}\n"
     "      libqasm_INCLUDE_DIRS: ${libqasm_INCLUDE_DIRS}\n"

--- a/conanfile.py
+++ b/conanfile.py
@@ -47,7 +47,6 @@ class QxConan(ConanFile):
             self.test_requires("gtest/1.15.0")
 
     def requirements(self):
-        self.requires("abseil/20230125.3", transitive_headers=True)
         self.requires("boost/1.85.0")
         self.requires("fmt/11.0.2", transitive_headers=True)
         self.requires("libqasm/0.6.7", transitive_headers=True)

--- a/include/qx/cqasm_v3x.hpp
+++ b/include/qx/cqasm_v3x.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "v3x/cqasm.hpp"  // default_analyzer
 #include "v3x/cqasm-analyzer.hpp"
 #include "v3x/cqasm-analysis-result.hpp"
 #include "v3x/cqasm-primitives.hpp"

--- a/include/qx/cqasm_v3x.hpp
+++ b/include/qx/cqasm_v3x.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "v3x/cqasm-analyzer.hpp"
 #include "v3x/cqasm-analysis-result.hpp"
 #include "v3x/cqasm-primitives.hpp"
 #include "v3x/cqasm-semantic-gen.hpp"

--- a/include/qx/cqasm_v3x.hpp
+++ b/include/qx/cqasm_v3x.hpp
@@ -1,15 +1,19 @@
 #pragma once
 
-#include "v3x/cqasm-semantic-gen.hpp"
+#include "v3x/cqasm.hpp"  // default_analyzer
+#include "v3x/cqasm-analyzer.hpp"
+#include "v3x/cqasm-analysis-result.hpp"
 #include "v3x/cqasm-primitives.hpp"
-#include "v3x/cqasm-types.hpp"
+#include "v3x/cqasm-semantic-gen.hpp"
 #include "v3x/cqasm-types-gen.hpp"
-#include "v3x/cqasm-values.hpp"
+#include "v3x/cqasm-types.hpp"
 #include "v3x/cqasm-values-gen.hpp"
+#include "v3x/cqasm-values.hpp"
 
 
 namespace qx {
 
+namespace cqasm_v3x_analyzer = cqasm::v3x::analyzer;
 namespace cqasm_v3x_ast = cqasm::v3x::ast;
 namespace cqasm_v3x_primitives = cqasm::v3x::primitives;
 namespace cqasm_v3x_semantic = cqasm::v3x::semantic;
@@ -17,6 +21,7 @@ namespace cqasm_v3x_tree = ::cqasm::tree;
 namespace cqasm_v3x_types = cqasm::v3x::types;
 namespace cqasm_v3x_values = cqasm::v3x::values;
 
+using CqasmV3xAnalysisResult = cqasm_v3x_analyzer::AnalysisResult;
 template <typename T>
 using CqasmV3xMany = cqasm_v3x_ast::Many<T>;
 using CqasmV3xConstInt = cqasm_v3x_values::ConstInt;

--- a/include/qx/simulation_result.hpp
+++ b/include/qx/simulation_result.hpp
@@ -5,11 +5,9 @@
 #include "qx/quantum_state.hpp"
 #include "qx/register_manager.hpp"
 
-#include <absl/container/btree_map.h>
-#include <compare>  // partial_ordering
-#include <complex>
 #include <cstdint>  // uint64_t
 #include <fmt/ostream.h>
+#include <map>
 #include <ostream>
 #include <string>
 #include <vector>
@@ -126,8 +124,8 @@ private:
     }
 
     core::QuantumState state;
-    absl::btree_map<state_string_t, count_t> measurements;
-    absl::btree_map<state_string_t, count_t> bit_measurements;
+    std::map<state_string_t, count_t> measurements;
+    std::map<state_string_t, count_t> bit_measurements;
 
     std::uint64_t measurements_count = 0;
     std::uint64_t bit_measurements_count = 0;

--- a/include/qx/sparse_array.hpp
+++ b/include/qx/sparse_array.hpp
@@ -1,13 +1,13 @@
 #pragma once
 
-#include <absl/container/flat_hash_map.h>
-#include <algorithm>  // for_each, sort
+#include <algorithm>  // erase_if, for_each, sort
 #include <complex>
 #include <cstdint>  // size_t, uint64_t
 #include <fmt/ostream.h>
 #include <numeric>  // accumulate
 #include <ostream>
 #include <stdexcept>  // runtime_error
+#include <unordered_map>
 #include <utility>  // pair
 #include <vector>
 
@@ -40,7 +40,7 @@ bool compareSparseElements(const SparseElement &lhs, const SparseElement &rhs);
 
 class SparseArray {
 public:
-    using MapBasisVectorToSparseComplex = absl::flat_hash_map<BasisVector, SparseComplex>;
+    using MapBasisVectorToSparseComplex = std::unordered_map<BasisVector, SparseComplex>;
     using VectorOfSparseElements = std::vector<SparseElement>;
     using Iterator = MapBasisVectorToSparseComplex::iterator;
     using ConstIterator = MapBasisVectorToSparseComplex::const_iterator;
@@ -86,7 +86,7 @@ public:
 
     template <typename F>
     void erase_if(F &&pred) {
-        absl::erase_if(data_, pred);
+        std::erase_if(data_, pred);
     }
 
     // Let f build a new SparseArray to replace *this, assuming f is linear.

--- a/src/qx/simulator.cpp
+++ b/src/qx/simulator.cpp
@@ -6,8 +6,6 @@
 #include "qx/register_manager.hpp"
 #include "qx/simulation_result.hpp"
 
-#include "v3x/cqasm.hpp"
-
 #include <fmt/format.h>
 #include <fmt/ranges.h>
 #include <iostream>
@@ -20,10 +18,6 @@
 namespace qx {
 
 namespace {
-
-// This alias has to go here and not in cqasm_v3x.hpp
-// Due to conflicts between absl, ANTLR, and SWIG
-using CqasmV3xAnalysisResult = cqasm::v3x::analyzer::AnalysisResult;
 
 CqasmV3xAnalysisResult parse_cqasm_v3x_file(std::string const &file_path) {
     auto analyzer = cqasm::v3x::default_analyzer("3.0");

--- a/src/qx/simulator.cpp
+++ b/src/qx/simulator.cpp
@@ -6,6 +6,9 @@
 #include "qx/register_manager.hpp"
 #include "qx/simulation_result.hpp"
 
+// This include can not go in cqasm_v3x.hpp, due to conflicts between ANTLR and SWIG
+#include "v3x/cqasm.hpp"  // default_analyzer
+
 #include <fmt/format.h>
 #include <fmt/ranges.h>
 #include <iostream>

--- a/src/qx/sparse_array.cpp
+++ b/src/qx/sparse_array.cpp
@@ -1,5 +1,6 @@
 #include "qx/sparse_array.hpp"
 
+#include <algorithm>  // erase_if
 #include <complex>
 #include <fmt/core.h>
 #include <fmt/ranges.h>
@@ -118,7 +119,7 @@ void SparseArray::clear() {
 }
 
 void SparseArray::clean_up_zeros() {
-    absl::erase_if(data_, [](auto const &kv) {
+    std::erase_if(data_, [](auto const &kv) {
         auto const &[_, sparse_complex] = kv;
         return is_null(sparse_complex.value);
     });


### PR DESCRIPTION
Remove `abseil` dependency:
- Use `std::map` instead of `absl::btree_map`.
- Use `std::unordered_map` instead of `absl::flat_hash_map`.
- Move `CqasmV3xAnalysisResult` from simulator.cpp to cqasm_v3x.hpp.

Update CHANGELOG.md.