### PR TITLE
[CQT-287] Implement `RegisterManager` as a singleton

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,13 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
-- Take measurement register out of `QuantumState`. 
-- Change `Circuit::execute` to return a `SimulationIterationContext`.
 - Implement instructions as a hierarchy.
-- Reimplement `GateConvertor` as a `CircuitBuilder`.
-- Change file, functions, and variable names.
+- Implement `GateConvertor` as a `CircuitBuilder`.
 - Implement `BasisVector` as a `boost::dynamic_bitset<uint32_t>`.
 - Implement `RegisterManager` as a singleton.
+- Change `QuantumState` by taking the measurement register out of it.
+- Change `Circuit::execute` to return a `SimulationIterationContext`.
+- Change file, functions, and variable names.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Reimplement `GateConvertor` as a `CircuitBuilder`.
 - Change file, functions, and variable names.
 - Implement `BasisVector` as a `boost::dynamic_bitset<uint32_t>`.
+- Implement `RegisterManager` as a singleton.
 
 ### Removed
 

--- a/include/qx/circuit.hpp
+++ b/include/qx/circuit.hpp
@@ -4,7 +4,6 @@
 #include "qx/cqasm_v3x.hpp"
 #include "qx/error_models.hpp"
 #include "qx/instructions.hpp"
-#include "qx/register_manager.hpp"
 #include "qx/simulation_result.hpp"
 
 #include <memory>  // shared_ptr
@@ -19,13 +18,12 @@ class Circuit {
     static void add_error(SimulationIterationContext &context, error_models::ErrorModel const &error_model);
 
 public:
-    Circuit(TreeOne<CqasmV3xProgram> const &program, RegisterManager const &register_manager);
+    Circuit(TreeOne<CqasmV3xProgram> const &program);
     void add_instruction(std::shared_ptr<Instruction> instruction);
     [[nodiscard]] SimulationIterationContext execute(error_models::ErrorModel const &error_model) const;
 
 public:
     TreeOne<CqasmV3xProgram> const &program;
-    RegisterManager const &register_manager;
 
 private:
     std::vector<std::shared_ptr<Instruction>> instructions_;

--- a/include/qx/circuit_builder.hpp
+++ b/include/qx/circuit_builder.hpp
@@ -2,7 +2,6 @@
 
 #include "qx/circuit.hpp"
 #include "qx/cqasm_v3x.hpp"
-#include "qx/register_manager.hpp"
 #include "qx/simulation_error.hpp"
 
 #include <algorithm>  // for_each

--- a/include/qx/cqasm_v3x.hpp
+++ b/include/qx/cqasm_v3x.hpp
@@ -19,20 +19,29 @@ namespace cqasm_v3x_semantic = cqasm::v3x::semantic;
 namespace cqasm_v3x_types = cqasm::v3x::types;
 namespace cqasm_v3x_values = cqasm::v3x::values;
 
-using CqasmV3xAnalysisResult = cqasm_v3x_analyzer::AnalysisResult;
+template <typename T>
+using CqasmV3xAny = cqasm_v3x_ast::Any<T>;
 template <typename T>
 using CqasmV3xMany = cqasm_v3x_ast::Many<T>;
+template <typename T>
+using TreeOne = cqasm_tree::One<T>;
+
+using CqasmV3xApiVersion = cqasm_v3x_primitives::Version;
+using CqasmV3xAnalysisResult = cqasm_v3x_analyzer::AnalysisResult;
+using CqasmV3xBitType = cqasm_v3x_types::Bit;
+using CqasmV3xBlock = cqasm_v3x_semantic::Block;
 using CqasmV3xConstInt = cqasm_v3x_values::ConstInt;
 using CqasmV3xIndices = CqasmV3xMany<CqasmV3xConstInt>;
 using CqasmV3xInstruction = cqasm_v3x_semantic::Instruction;
 using CqasmV3xNode = cqasm_v3x_semantic::Node;
 using CqasmV3xProgram = cqasm_v3x_semantic::Program;
+using CqasmV3xQubitType = cqasm_v3x_types::Qubit;
 using CqasmV3xRecursiveVisitor = cqasm_v3x_semantic::RecursiveVisitor;
 using CqasmV3xType = cqasm_v3x_types::Type;
 using CqasmV3xValue = cqasm_v3x_values::Value;
 using CqasmV3xVariable = cqasm_v3x_semantic::Variable;
-template <typename T>
-using TreeOne = cqasm_tree::One<T>;
+using CqasmV3xVariables = CqasmV3xAny<CqasmV3xVariable>;
+using CqasmV3xVersion = cqasm_v3x_semantic::Version;
 
 bool is_qubit_variable(const CqasmV3xVariable &variable);
 bool is_bit_variable(const CqasmV3xVariable &variable);

--- a/include/qx/cqasm_v3x.hpp
+++ b/include/qx/cqasm_v3x.hpp
@@ -11,11 +11,11 @@
 
 namespace qx {
 
+namespace cqasm_tree = ::cqasm::tree;
 namespace cqasm_v3x_analyzer = cqasm::v3x::analyzer;
 namespace cqasm_v3x_ast = cqasm::v3x::ast;
 namespace cqasm_v3x_primitives = cqasm::v3x::primitives;
 namespace cqasm_v3x_semantic = cqasm::v3x::semantic;
-namespace cqasm_v3x_tree = ::cqasm::tree;
 namespace cqasm_v3x_types = cqasm::v3x::types;
 namespace cqasm_v3x_values = cqasm::v3x::values;
 
@@ -32,7 +32,7 @@ using CqasmV3xType = cqasm_v3x_types::Type;
 using CqasmV3xValue = cqasm_v3x_values::Value;
 using CqasmV3xVariable = cqasm_v3x_semantic::Variable;
 template <typename T>
-using TreeOne = cqasm_v3x_tree::One<T>;
+using TreeOne = cqasm_tree::One<T>;
 
 bool is_qubit_variable(const CqasmV3xVariable &variable);
 bool is_bit_variable(const CqasmV3xVariable &variable);

--- a/include/qx/operands_helper.hpp
+++ b/include/qx/operands_helper.hpp
@@ -14,13 +14,12 @@ class RegisterManager;
  */
 class OperandsHelper {
 public:
-    OperandsHelper(const CqasmV3xInstruction &instruction, const RegisterManager &register_manager);
+    OperandsHelper(const CqasmV3xInstruction &instruction);
     [[nodiscard]] CqasmV3xIndices get_register_operand(int id) const;
     [[nodiscard]] double get_float_operand(int id) const;
     [[nodiscard]] std::int64_t get_int_operand(int id) const;
 private:
     const CqasmV3xInstruction &instruction_;
-    const RegisterManager &register_manager_;
 };
 
 } // namespace qx

--- a/include/qx/quantum_state.hpp
+++ b/include/qx/quantum_state.hpp
@@ -13,7 +13,6 @@
 #include "qx/core.hpp"  // BasisVector, BitMeasurementRegister, MeasurementRegister, QubitIndex
 #include "qx/dense_unitary_matrix.hpp"
 #include "qx/gates.hpp"
-#include "qx/register_manager.hpp"
 #include "qx/sparse_array.hpp"
 #include "qx/utils.hpp"
 

--- a/include/qx/register_manager.hpp
+++ b/include/qx/register_manager.hpp
@@ -39,12 +39,21 @@ struct Range {
 };
 
 
+//----------------------//
+// RegisterManagerError //
+//----------------------//
+
 struct RegisterManagerError : public SimulationError {
     explicit RegisterManagerError(const std::string &message);
 };
 
 using VariableNameToRangeMapT = std::unordered_map<VariableName, Range>;
 using IndexToVariableNameMapT = std::vector<VariableName>;
+
+
+//----------//
+// Register //
+//----------//
 
 class Register {
     std::size_t register_size_;
@@ -61,12 +70,20 @@ public:
 };
 
 
+//---------------//
+// QubitRegister //
+//---------------//
+
 class QubitRegister : public Register {
 public:
     explicit QubitRegister(const TreeOne<CqasmV3xProgram> &program);
     ~QubitRegister() override;
 };
 
+
+//-------------//
+// BitRegister //
+//-------------//
 
 class BitRegister : public Register {
 public:
@@ -75,16 +92,24 @@ public:
 };
 
 
+//-----------------//
+// RegisterManager //
+//-----------------//
+
 class RegisterManager {
     QubitRegister qubit_register_;
     BitRegister bit_register_;
+
+    explicit RegisterManager(const TreeOne<CqasmV3xProgram> &program);
+    [[nodiscard]] static RegisterManager& get_instance_impl(const TreeOne<CqasmV3xProgram> &program);
 public:
     RegisterManager(const RegisterManager&) = delete;
     RegisterManager(RegisterManager&&) noexcept = delete;
     RegisterManager& operator=(const RegisterManager&) = default;
     RegisterManager& operator=(RegisterManager&&) noexcept = default;
 public:
-    explicit RegisterManager(const TreeOne<CqasmV3xProgram> &program);
+    static void create_instance(const TreeOne<CqasmV3xProgram> &program);
+    [[nodiscard]] static RegisterManager& get_instance();
     [[nodiscard]] std::size_t get_qubit_register_size() const;
     [[nodiscard]] std::size_t get_bit_register_size() const;
     [[nodiscard]] Range get_qubit_range(const VariableName &name) const;

--- a/include/qx/simulation_result.hpp
+++ b/include/qx/simulation_result.hpp
@@ -3,7 +3,7 @@
 #include "qx/compile_time_configuration.hpp"
 #include "qx/core.hpp" // BasisVector, BitMeasurementRegister Complex
 #include "qx/quantum_state.hpp"
-#include "qx/register_manager.hpp"
+#include "qx/register_manager.hpp"  // Index
 
 #include <cstdint>  // uint64_t
 #include <fmt/ostream.h>
@@ -61,7 +61,7 @@ struct SimulationResult {
     using State = std::vector<SuperposedState>;
 
 public:
-    SimulationResult(std::uint64_t requestedShots, std::uint64_t doneShots, RegisterManager const& register_manager);
+    SimulationResult(std::uint64_t requestedShots, std::uint64_t doneShots);
 
     // Given a state string from the State vector, a qubit variable name, and an optional sub index,
     // return the value of that qubit in the state string
@@ -100,7 +100,7 @@ struct SimulationIterationContext {
     core::BasisVector measurement_register;
     core::BitMeasurementRegister bit_measurement_register;
 
-    explicit SimulationIterationContext(RegisterManager const& register_manager);
+    explicit SimulationIterationContext();
 };
 
 
@@ -113,7 +113,7 @@ public:
     void add(const SimulationIterationContext &context);
     void append_measurement(core::BasisVector const& measurement);
     void append_bit_measurement(core::BitMeasurementRegister const& bit_measurement);
-    SimulationResult get_simulation_result(RegisterManager const& register_manager);
+    SimulationResult get_simulation_result();
 
 private:
     template <typename F>

--- a/src/qx/circuit.cpp
+++ b/src/qx/circuit.cpp
@@ -8,9 +8,8 @@
 
 namespace qx {
 
-Circuit::Circuit(TreeOne<CqasmV3xProgram> const &program, RegisterManager const &register_manager)
+Circuit::Circuit(TreeOne<CqasmV3xProgram> const &program)
     : program{ program }
-    , register_manager{ register_manager }
 {
     CircuitBuilder{ *this }.build();
 }
@@ -29,7 +28,7 @@ void Circuit::add_instruction(std::shared_ptr<Instruction> instruction) {
 }
 
 [[nodiscard]] SimulationIterationContext Circuit::execute(error_models::ErrorModel const &error_model) const {
-    auto context = SimulationIterationContext{ register_manager };
+    auto context = SimulationIterationContext{};
     std::for_each(instructions_.begin(), instructions_.end(),
         [&context, &error_model](auto const& instruction) {
             add_error(context, error_model);

--- a/src/qx/circuit_builder.cpp
+++ b/src/qx/circuit_builder.cpp
@@ -30,7 +30,7 @@ void CircuitBuilder::visit_node(CqasmV3xNode &) {
 
 void CircuitBuilder::visit_instruction(CqasmV3xInstruction &instruction) {
     auto &name = instruction.instruction_ref->name;
-    auto operands_helper = OperandsHelper{ instruction, circuit_.register_manager };
+    auto operands_helper = OperandsHelper{ instruction };
     
     if (name == "TOFFOLI") {
         visit_gate_instruction<3>(

--- a/src/qx/operands_helper.cpp
+++ b/src/qx/operands_helper.cpp
@@ -8,27 +8,27 @@
 
 namespace qx {
 
-OperandsHelper::OperandsHelper(const CqasmV3xInstruction &instruction, const RegisterManager &register_manager)
+OperandsHelper::OperandsHelper(const CqasmV3xInstruction &instruction)
     : instruction_{ instruction }
-    , register_manager_{ register_manager }
 {}
 
 [[nodiscard]] CqasmV3xIndices OperandsHelper::get_register_operand(int id) const {
+    const auto &register_manager = RegisterManager::get_instance();
     if (auto variable_ref = instruction_.operands[id]->as_variable_ref()) {
         auto ret = CqasmV3xIndices{};
         if (is_qubit_variable(*variable_ref->variable)) {
-            auto qubit_range = register_manager_.get_qubit_range(variable_ref->variable->name);
+            auto qubit_range = register_manager.get_qubit_range(variable_ref->variable->name);
             ret.get_vec().resize(qubit_range.size);
             std::generate_n(ret.get_vec().begin(), qubit_range.size, [qubit_range, i=0]() mutable {
-                return cqasm_v3x_tree::make<CqasmV3xConstInt>(
+                return cqasm_tree::make<CqasmV3xConstInt>(
                     static_cast<cqasm_v3x_primitives::Int>(qubit_range.first + i++)
                 );
             });
         } else if (is_bit_variable(*variable_ref->variable)) {
-            auto bit_range = register_manager_.get_bit_range(variable_ref->variable->name);
+            auto bit_range = register_manager.get_bit_range(variable_ref->variable->name);
             ret.get_vec().resize(bit_range.size);
             std::generate_n(ret.get_vec().begin(), bit_range.size, [bit_range, i=0]() mutable {
-                return cqasm_v3x_tree::make<CqasmV3xConstInt>(
+                return cqasm_tree::make<CqasmV3xConstInt>(
                     static_cast<cqasm_v3x_primitives::Int>(bit_range.first + i++)
                 );
             });
@@ -39,12 +39,12 @@ OperandsHelper::OperandsHelper(const CqasmV3xInstruction &instruction, const Reg
     } else if (auto index_ref = instruction_.operands[id]->as_index_ref()) {
         auto ret = index_ref->indices;
         if (is_qubit_variable(*index_ref->variable)) {
-            auto qubit_range = register_manager_.get_qubit_range(index_ref->variable->name);
+            auto qubit_range = register_manager.get_qubit_range(index_ref->variable->name);
             std::for_each(ret.get_vec().begin(), ret.get_vec().end(), [qubit_range](const auto &index) {
                 index->value += qubit_range.first;
             });
         } else if (is_bit_variable(*index_ref->variable)) {
-            auto bit_range = register_manager_.get_bit_range(index_ref->variable->name);
+            auto bit_range = register_manager.get_bit_range(index_ref->variable->name);
             std::for_each(ret.get_vec().begin(), ret.get_vec().end(), [bit_range](const auto &index) {
                 index->value += bit_range.first;
             });

--- a/src/qx/register_manager.cpp
+++ b/src/qx/register_manager.cpp
@@ -29,13 +29,16 @@ Register::Register(const TreeOne<CqasmV3xProgram> &program, auto &&is_of_type, s
         throw RegisterManagerError{ "null pointer to program" };
     }
     auto &&variables = program->variables.get_vec()
-       | ranges::views::filter([&](const TreeOne<CqasmV3xVariable> &variable) { return is_of_type(*variable); });
+       | ranges::views::filter(
+            [&](const TreeOne<CqasmV3xVariable> &variable) { return is_of_type(*variable); });
     auto &&variable_sizes = variables
-        | ranges::views::transform([](const TreeOne<CqasmV3xVariable> &variable) { return cqasm_v3x_types::size_of(variable->typ); });
+        | ranges::views::transform(
+            [](const TreeOne<CqasmV3xVariable> &variable) { return cqasm_v3x_types::size_of(variable->typ); });
     register_size_ = ranges::accumulate(variable_sizes, size_t{});
 
     if (register_size_ > max_register_size) {
-        throw RegisterManagerError{ fmt::format("{}", register_size_) };
+        throw RegisterManagerError{ fmt::format("register size exceeds maximum allowed: {} > {}",
+                                                register_size_, max_register_size) };
     }
 
     variable_name_to_range_.reserve(register_size_);
@@ -87,12 +90,9 @@ Register::~Register() = default;
 // QubitRegister //
 //---------------//
 
-QubitRegister::QubitRegister(const TreeOne<CqasmV3xProgram> &program) try
-    : Register(program, is_qubit_variable, config::MAX_QUBIT_NUMBER) {
-} catch (const RegisterManagerError &e) {
-    throw RegisterManagerError{ fmt::format("qubit register size exceeds maximum allowed: {} > {}",
-                                            e.what(), config::MAX_QUBIT_NUMBER) };
-}
+QubitRegister::QubitRegister(const TreeOne<CqasmV3xProgram> &program)
+    : Register(program, is_qubit_variable, config::MAX_QUBIT_NUMBER)
+{}
 
 QubitRegister::~QubitRegister() = default;
 
@@ -101,12 +101,9 @@ QubitRegister::~QubitRegister() = default;
 // RegisterManager //
 //-----------------//
 
-BitRegister::BitRegister(const TreeOne<CqasmV3xProgram> &program) try
-    : Register(program, is_bit_variable, config::MAX_BIT_NUMBER) {
-} catch (const RegisterManagerError &e) {
-    throw RegisterManagerError{ fmt::format("bit register size exceeds maximum allowed: {} > {}",
-                                            e.what(), config::MAX_BIT_NUMBER) };
-}
+BitRegister::BitRegister(const TreeOne<CqasmV3xProgram> &program)
+    : Register(program, is_bit_variable, config::MAX_BIT_NUMBER)
+{}
 
 BitRegister::~BitRegister() = default;
 

--- a/src/qx/simulation_result.cpp
+++ b/src/qx/simulation_result.cpp
@@ -1,5 +1,6 @@
 #include "qx/core.hpp" // BasisVector
 #include "qx/quantum_state.hpp"
+#include "qx/register_manager.hpp"
 #include "qx/simulation_result.hpp"
 
 #include <cstdint>  // uint8_t
@@ -14,12 +15,11 @@ namespace qx {
 // SimulationResult //
 //------------------//
 
-SimulationResult::SimulationResult(std::uint64_t requestedShots, std::uint64_t doneShots,
-                                   RegisterManager const& register_manager)
+SimulationResult::SimulationResult(std::uint64_t requestedShots, std::uint64_t doneShots)
     : shots_requested{ requestedShots }
     , shots_done{ doneShots }
-    , qubit_register{ register_manager.get_qubit_register() }
-    , bit_register{ register_manager.get_bit_register() }
+    , qubit_register{ RegisterManager::get_instance().get_qubit_register() }
+    , bit_register{ RegisterManager::get_instance().get_bit_register() }
 {}
 
 std::uint8_t SimulationResult::get_qubit_state(state_string_t const& state_string, std::string const& qubit_variable_name,
@@ -72,10 +72,13 @@ std::ostream &operator<<(std::ostream &os, const SimulationResult &simulation_re
 // SimulationIterationContext //
 //----------------------------//
 
-SimulationIterationContext::SimulationIterationContext(RegisterManager const& register_manager)
-    : state{ register_manager.get_qubit_register_size(), register_manager.get_bit_register_size() }
-    , measurement_register{ register_manager.get_qubit_register_size() }
-    , bit_measurement_register{ register_manager.get_bit_register_size() }
+SimulationIterationContext::SimulationIterationContext()
+    : state{
+          RegisterManager::get_instance().get_qubit_register_size(),
+          RegisterManager::get_instance().get_bit_register_size()
+      }
+    , measurement_register{ RegisterManager::get_instance().get_qubit_register_size() }
+    , bit_measurement_register{ RegisterManager::get_instance().get_bit_register_size() }
 {}
 
 
@@ -103,10 +106,10 @@ void SimulationIterationAccumulator::append_bit_measurement(core::BitMeasurement
     bit_measurements_count++;
 }
 
-SimulationResult SimulationIterationAccumulator::get_simulation_result(RegisterManager const& register_manager) {
+SimulationResult SimulationIterationAccumulator::get_simulation_result() {
     assert(measurements_count > 0);
 
-    SimulationResult simulation_result{ measurements_count, measurements_count, register_manager };
+    SimulationResult simulation_result{ measurements_count, measurements_count };
 
     forAllNonZeroStates(
         [this, &simulation_result](core::BasisVector const& superposed_state, core::SparseComplex const& sparse_complex) {

--- a/src/qx/simulator.cpp
+++ b/src/qx/simulator.cpp
@@ -62,15 +62,15 @@ std::variant<std::monostate, SimulationResult, SimulationError> execute(
     }
 
     try {
-        auto register_manager = RegisterManager{ program };
-        auto circuit = Circuit{ program, register_manager };
+        RegisterManager::create_instance(program);
+        auto circuit = Circuit{ program };
         auto simulation_iteration_accumulator = ranges::accumulate(
             ranges::views::iota(static_cast<size_t>(0), iterations),
             SimulationIterationAccumulator{}, [&circuit](auto &acc, auto) {
                 acc.add(circuit.execute(std::monostate{}));
                 return acc;
             });
-        return simulation_iteration_accumulator.get_simulation_result(register_manager);
+        return simulation_iteration_accumulator.get_simulation_result();
     } catch (const SimulationError &err) {
         return err;
     }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -12,6 +12,7 @@ target_sources(${PROJECT_NAME}_test PRIVATE
     "${CMAKE_CURRENT_SOURCE_DIR}/main.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/quantum_state_test.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/random_test.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/register_manager.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/sparse_array_test.cpp"
 )
 

--- a/test/integration_test.cpp
+++ b/test/integration_test.cpp
@@ -10,9 +10,8 @@ namespace qx {
 
 class IntegrationTest : public ::testing::Test {
 public:
-    static SimulationResult run_from_string(
-        const std::string &s, std::uint64_t iterations = 1, std::string cqasm_version = "3.0") {
-
+    static SimulationResult run_from_string(const std::string &s, std::uint64_t iterations = 1,
+                                            std::string cqasm_version = "3.0") {
         auto result = execute_string(s, iterations, std::nullopt, std::move(cqasm_version));
         EXPECT_TRUE(std::holds_alternative<SimulationResult>(result));
         return *std::get_if<SimulationResult>(&result);
@@ -60,13 +59,12 @@ CNOT q[0:2], q[3:5]
         (SimulationResult::State{ { "111111", core::Complex{ .real = 1, .imag = 0, .norm = 1 } } }));
 }
 
-TEST_F(IntegrationTest, too_many_qubits) {
-    EXPECT_TRUE(std::holds_alternative<SimulationResult>(execute_string("version 3.0; qubit[62] q")));
-    EXPECT_TRUE(std::holds_alternative<SimulationResult>(execute_string("version 3.0; qubit[63] q")));
+TEST_F(IntegrationTest, max_qubit_number) {
     EXPECT_TRUE(std::holds_alternative<SimulationResult>(execute_string("version 3.0; qubit[64] q")));
+}
 
+TEST_F(IntegrationTest, too_many_qubits) {
     EXPECT_TRUE(std::holds_alternative<SimulationError>(execute_string("version 3.0; qubit[65] q")));
-    EXPECT_TRUE(std::holds_alternative<SimulationError>(execute_string("version 3.0; qubit[66] q")));
 }
 
 TEST_F(IntegrationTest, syntax_error) {

--- a/test/register_manager.cpp
+++ b/test/register_manager.cpp
@@ -1,0 +1,91 @@
+#include "qx/compile_time_configuration.hpp"
+#include "qx/cqasm_v3x.hpp"
+#include "qx/register_manager.hpp"
+
+#include <fmt/format.h>
+#include <gmock/gmock.h>  // ThrowsMessage
+#include <gtest/gtest.h>
+#include <stdexcept>  // runtime_error
+
+
+namespace qx {
+
+class RegisterManagerTest : public ::testing::Test {
+protected:
+    void SetUp() override {}
+
+    CqasmV3xApiVersion api_version = CqasmV3xApiVersion{ "3.0" };
+    TreeOne<CqasmV3xVersion> version = cqasm_tree::make<CqasmV3xVersion>("3.0");
+    TreeOne<CqasmV3xBlock> empty_block = cqasm_tree::make<CqasmV3xBlock>();
+    TreeOne<CqasmV3xVariable> qubit_register_of_size_2 = cqasm_tree::make<CqasmV3xVariable>(
+        "qr_of_size_2", cqasm_tree::make<CqasmV3xQubitType>(2));
+    TreeOne<CqasmV3xVariable> qubit_register_of_size_4 = cqasm_tree::make<CqasmV3xVariable>(
+        "qr_of_size_4", cqasm_tree::make<CqasmV3xQubitType>(4));
+    TreeOne<CqasmV3xVariable> too_long_qubit_register = cqasm_tree::make<CqasmV3xVariable>(
+        "too_long_qr", cqasm_tree::make<CqasmV3xQubitType>(qx::config::MAX_QUBIT_NUMBER + 1));
+    TreeOne<CqasmV3xVariable> too_long_bit_register = cqasm_tree::make<CqasmV3xVariable>(
+        "too_long_br", cqasm_tree::make<CqasmV3xBitType>(qx::config::MAX_BIT_NUMBER + 1));
+    TreeOne<CqasmV3xProgram> null_program = TreeOne<CqasmV3xProgram>{};
+    TreeOne<CqasmV3xProgram> program_with_2_qubits = cqasm_tree::make<CqasmV3xProgram>(
+        api_version, version, empty_block, CqasmV3xVariables{ qubit_register_of_size_2 }
+    );
+    TreeOne<CqasmV3xProgram> program_with_4_qubits = cqasm_tree::make<CqasmV3xProgram>(
+        api_version, version, empty_block, CqasmV3xVariables{ qubit_register_of_size_4 }
+    );
+    TreeOne<CqasmV3xProgram> program_with_too_long_qubit_register = cqasm_tree::make<CqasmV3xProgram>(
+        api_version, version, empty_block, CqasmV3xVariables{ too_long_qubit_register }
+    );
+    TreeOne<CqasmV3xProgram> program_with_too_long_bit_register = cqasm_tree::make<CqasmV3xProgram>(
+        api_version, version, empty_block, CqasmV3xVariables{ too_long_bit_register }
+    );
+};
+
+TEST_F(RegisterManagerTest, qubit_register_size_exceeds_maximum_allowed) {
+    EXPECT_THAT(
+        [this]() {
+            [[maybe_unused]] auto qubit_register = QubitRegister{ program_with_too_long_qubit_register };
+        },
+        ::testing::ThrowsMessage<std::runtime_error>(
+            fmt::format("register size exceeds maximum allowed: {} > {}",
+                        qx::config::MAX_QUBIT_NUMBER + 1, qx::config::MAX_QUBIT_NUMBER)
+        )
+    );
+}
+
+TEST_F(RegisterManagerTest, bit_register_size_exceeds_maximum_allowed) {
+    EXPECT_THAT(
+        [this]() {
+            [[maybe_unused]] auto bit_register = BitRegister{ program_with_too_long_bit_register };
+        },
+        ::testing::ThrowsMessage<std::runtime_error>(
+            fmt::format("register size exceeds maximum allowed: {} > {}",
+                        qx::config::MAX_BIT_NUMBER + 1, qx::config::MAX_BIT_NUMBER)
+        )
+    );
+}
+
+TEST_F(RegisterManagerTest, create_instance_with_null_program) {
+    EXPECT_THAT(
+        [this]() {
+            RegisterManager::create_instance(null_program);
+            [[maybe_unused]] const auto &unused = RegisterManager::get_instance();
+        },
+        ::testing::ThrowsMessage<std::runtime_error>("null pointer to program")
+    );
+}
+
+TEST_F(RegisterManagerTest, get_instance_before_create_instance) {
+    EXPECT_THAT(
+        []() { [[maybe_unused]] const auto &unused = RegisterManager::get_instance(); },
+        ::testing::ThrowsMessage<std::runtime_error>("null pointer to program")
+    );
+}
+
+TEST_F(RegisterManagerTest, get_instance_after_two_calls_to_create_instance) {
+    RegisterManager::create_instance(program_with_2_qubits);
+    RegisterManager::create_instance(program_with_4_qubits);
+    const auto &register_manager = RegisterManager::get_instance();
+    EXPECT_EQ(register_manager.get_qubit_register_size(), 2);
+}
+
+}  // namespace qx


### PR DESCRIPTION
There is one instance of RegisterManager per execution.
The instance is:
- created via `RegisterManager::create_instance` at `execute` function in simulator.cpp,
- and then obtained via `RegisterManager::get_instance`.
  There is no need for passing around RegisterManager instances anymore.

Divide `too_many_qubits` test into two: `max_qubit_number` and `too_many_qubits`:
- Every test case needs to run a new fresh version of the simulator.
- Otherwise, we would be reusing the RegisterManager instance.
- This can be accomplished by having two separate tests for every case.

Add test/register_manager.cpp.

Rename `cqasm_v3x_tree` namespace to `cqasm_tree`.

Update CHANGELOG.md.