### PR TITLE
Integrate libQASM 0.6.9 into QX simulator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,22 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - **Removed** for now removed features.
 
 
+## [ 0.7.4 ] - [ xxxx-yy-zz ]
+
+### Added
+- Integrate with libqasm 0.6.9 release:
+  - Add `SWAP` gate instruction.
+  - Add `barrier`, `wait`, and `ìnit` non-gate instructions.
+- The register manager now holds a 'dirty bitset' for virtual qubit and bit indices.
+
+
 ## [ 0.7.3 ] - [ 2025-01-27 ]
 
 ### Added
-- Documentation: GitHub pages.
-- Linters: `.clang-format` and `.clang-tidy`.
 - Integrate with libqasm 0.6.8 release:
   - Add gate modifiers. Notice though that `pow` only works with integer exponents.
+- Documentation: GitHub pages.
+- Linters: `.clang-format` and `.clang-tidy`.
 
 ### Changed
 - Implement instructions as a hierarchy.

--- a/conanfile.py
+++ b/conanfile.py
@@ -42,14 +42,14 @@ class QxConan(ConanFile):
         return not self.conf.get("tools.build:skip_test", default=True, check_type=bool)
 
     def build_requirements(self):
-        self.tool_requires("libqasm/0.6.8")
+        self.tool_requires("libqasm/0.6.9")
         if self._should_build_test:
             self.test_requires("gtest/1.15.0")
 
     def requirements(self):
         self.requires("boost/1.85.0")
         self.requires("fmt/11.0.2", transitive_headers=True)
-        self.requires("libqasm/0.6.8", transitive_headers=True)
+        self.requires("libqasm/0.6.9", transitive_headers=True)
         self.requires("range-v3/0.12.0", transitive_headers=True)
 
     def config_options(self):

--- a/include/qx/instructions.hpp
+++ b/include/qx/instructions.hpp
@@ -13,9 +13,14 @@ namespace qx {
 
 using ControlBits = std::vector<core::BitIndex>;
 
+using qubit_indices_t = std::vector<core::QubitIndex>;
+using bit_indices_t = std::vector<core::BitIndex>;
+
 struct Instruction {
     virtual ~Instruction() = default;
     virtual void execute(SimulationIterationContext& context) = 0;
+    [[nodiscard]] virtual qubit_indices_t get_qubit_indices() = 0;
+    [[nodiscard]] virtual bit_indices_t get_bit_indices() = 0;
 };
 
 struct BitControlledInstruction : public Instruction {
@@ -25,6 +30,8 @@ struct BitControlledInstruction : public Instruction {
     ~BitControlledInstruction() override = default;
     BitControlledInstruction(ControlBits control_bits, std::shared_ptr<Instruction> instruction);
     void execute(SimulationIterationContext& context) override;
+    [[nodiscard]] qubit_indices_t get_qubit_indices() override;
+    [[nodiscard]] bit_indices_t get_bit_indices() override;
 };
 
 struct Unitary : public Instruction {
@@ -37,11 +44,15 @@ struct Unitary : public Instruction {
     [[nodiscard]] std::shared_ptr<core::matrix_t> inverse() const;
     [[nodiscard]] std::shared_ptr<core::matrix_t> power(double exponent) const;
     [[nodiscard]] std::shared_ptr<core::matrix_t> control() const;
+    [[nodiscard]] qubit_indices_t get_qubit_indices() override;
+    [[nodiscard]] bit_indices_t get_bit_indices() override;
 };
 
 struct NonUnitary : public Instruction {
     ~NonUnitary() override = default;
     void execute(SimulationIterationContext& context) override = 0;
+    [[nodiscard]] qubit_indices_t get_qubit_indices() override = 0;
+    [[nodiscard]] bit_indices_t get_bit_indices() override = 0;
 };
 
 struct Measure : public NonUnitary {
@@ -51,6 +62,8 @@ struct Measure : public NonUnitary {
     ~Measure() override = default;
     Measure(const core::QubitIndex& qubit_index, const core::BitIndex& bit_index);
     void execute(SimulationIterationContext& context) override;
+    [[nodiscard]] qubit_indices_t get_qubit_indices() override;
+    [[nodiscard]] bit_indices_t get_bit_indices() override;
 };
 
 struct Reset : public NonUnitary {
@@ -59,6 +72,8 @@ struct Reset : public NonUnitary {
     ~Reset() override = default;
     explicit Reset(std::optional<core::QubitIndex> qubit_index);
     void execute(SimulationIterationContext& context) override;
+    [[nodiscard]] qubit_indices_t get_qubit_indices() override;
+    [[nodiscard]] bit_indices_t get_bit_indices() override;
 };
 
 }  // namespace qx

--- a/include/qx/register_manager.hpp
+++ b/include/qx/register_manager.hpp
@@ -71,7 +71,6 @@ public:
     [[nodiscard]] virtual std::string to_string() const;
     [[nodiscard]] virtual bool is_dirty(const Index& index) const;
     virtual void set_dirty(const Index& index);
-
 };
 
 //---------------//

--- a/include/qx/register_manager.hpp
+++ b/include/qx/register_manager.hpp
@@ -2,6 +2,7 @@
 
 #include <fmt/ostream.h>
 
+#include <boost/dynamic_bitset/dynamic_bitset.hpp>
 #include <cstdint>  // size_t
 #include <memory>  // shared_ptr
 #include <optional>
@@ -48,6 +49,7 @@ struct RegisterManagerError : public SimulationError {
 
 using VariableNameToRangeMapT = std::unordered_map<VariableName, Range>;
 using IndexToVariableNameMapT = std::vector<VariableName>;
+using DirtyBitsetT = boost::dynamic_bitset<uint32_t>;
 
 //----------//
 // Register //
@@ -57,6 +59,7 @@ class Register {
     std::size_t register_size_;
     VariableNameToRangeMapT variable_name_to_range_;
     IndexToVariableNameMapT index_to_variable_name_;
+    DirtyBitsetT dirty_bitset_;
 
 public:
     Register(const TreeOne<CqasmV3xProgram>& program, auto&& is_of_type, std::size_t max_register_size);
@@ -64,8 +67,11 @@ public:
     [[nodiscard]] std::size_t size() const;
     [[nodiscard]] virtual Range at(const VariableName& name) const;
     [[nodiscard]] virtual Index at(const VariableName& name, const std::optional<Index>& sub_index) const;
-    [[nodiscard]] virtual VariableName at(const std::size_t& index) const;
+    [[nodiscard]] virtual VariableName at(const Index& index) const;
     [[nodiscard]] virtual std::string to_string() const;
+    [[nodiscard]] virtual bool is_dirty(const Index& index) const;
+    virtual void set_dirty(const Index& index);
+
 };
 
 //---------------//
@@ -116,8 +122,14 @@ public:
     [[nodiscard]] Index get_bit_index(const VariableName& name, const std::optional<Index>& sub_index) const;
     [[nodiscard]] VariableName get_qubit_variable_name(const Index& index) const;
     [[nodiscard]] VariableName get_bit_variable_name(const Index& index) const;
+    [[nodiscard]] Index get_qubit_variable_index(const Index& index) const;
+    [[nodiscard]] Index get_bit_variable_index(const Index& index) const;
     [[nodiscard]] std::shared_ptr<QubitRegister> get_qubit_register() const;
     [[nodiscard]] std::shared_ptr<BitRegister> get_bit_register() const;
+    [[nodiscard]] bool is_dirty_qubit(const Index& index) const;
+    [[nodiscard]] bool is_dirty_bit(const Index& index) const;
+    void set_dirty_qubit(const Index& index);
+    void set_dirty_bit(const Index& index);
 };
 
 std::ostream& operator<<(std::ostream& os, const Range& range);

--- a/src/qx/circuit.cpp
+++ b/src/qx/circuit.cpp
@@ -14,6 +14,9 @@ Circuit::Circuit(const TreeOne<CqasmV3xProgram>& program)
 }
 
 void Circuit::add_instruction(std::shared_ptr<Instruction> instruction) {
+    for (const auto& qubit_index : instruction->get_qubit_indices()) {
+        RegisterManager::get_instance().set_dirty_qubit(qubit_index.value);
+    }
     instructions_.emplace_back(std::move(instruction));
 }
 

--- a/src/qx/circuit_builder.cpp
+++ b/src/qx/circuit_builder.cpp
@@ -109,11 +109,23 @@ void CircuitBuilder::visit_non_gate_instruction(CqasmV3xNonGateInstruction& non_
                 const auto& variable_name = register_manager.get_qubit_variable_name(qubit_index.value);
                 const auto& variable_index = register_manager.get_qubit_variable_index(qubit_index.value);
                 throw CircuitBuilderError{ fmt::format(
-                    "trying to 'init {}[{}]' but qubit is not in ground state", variable_name, variable_index) };
+                    "incorrect 'init {}[{}]': the qubit has already been used in a non-control instruction",
+                    variable_name,
+                    variable_index) };
             }
         }
     } else if (name == "barrier") {
     } else if (name == "wait") {
+        auto time = non_gate_instruction.parameter->as_const_int()->value;
+        if (time < 0) {
+            const auto& instruction_indices = instructions_indices[0];
+            const auto& qubit_index = instruction_indices[0];
+            const auto& register_manager = RegisterManager::get_instance();
+            const auto& variable_name = register_manager.get_qubit_variable_name(qubit_index.value);
+            const auto& variable_index = register_manager.get_qubit_variable_index(qubit_index.value);
+            throw CircuitBuilderError{ fmt::format(
+                "incorrect 'wait({}) {}[{}]': time cannot be negative", time, variable_name, variable_index) };
+        }
     } else {
         throw CircuitBuilderError{ fmt::format("unsupported non-gate instruction: '{}'", name) };
     }

--- a/src/qx/circuit_builder.cpp
+++ b/src/qx/circuit_builder.cpp
@@ -108,9 +108,8 @@ void CircuitBuilder::visit_non_gate_instruction(CqasmV3xNonGateInstruction& non_
             if (register_manager.is_dirty_qubit(qubit_index.value)) {
                 const auto& variable_name = register_manager.get_qubit_variable_name(qubit_index.value);
                 const auto& variable_index = register_manager.get_qubit_variable_index(qubit_index.value);
-                throw CircuitBuilderError{ fmt::format("trying to 'init {}[{}]' but qubit is not in ground state",
-                    variable_name,
-                    variable_index) };
+                throw CircuitBuilderError{ fmt::format(
+                    "trying to 'init {}[{}]' but qubit is not in ground state", variable_name, variable_index) };
             }
         }
     } else if (name == "barrier") {

--- a/src/qx/circuit_builder.cpp
+++ b/src/qx/circuit_builder.cpp
@@ -102,6 +102,17 @@ void CircuitBuilder::visit_non_gate_instruction(CqasmV3xNonGateInstruction& non_
             }
         }
     } else if (name == "init") {
+        for (const auto& instruction_indices : instructions_indices) {
+            const auto& qubit_index = instruction_indices[0];
+            const auto& register_manager = RegisterManager::get_instance();
+            if (register_manager.is_dirty_qubit(qubit_index.value)) {
+                const auto& variable_name = register_manager.get_qubit_variable_name(qubit_index.value);
+                const auto& variable_index = register_manager.get_qubit_variable_index(qubit_index.value);
+                throw CircuitBuilderError{ fmt::format("trying to 'init {}[{}]' but qubit is not in ground state",
+                    variable_name,
+                    variable_index) };
+            }
+        }
     } else if (name == "barrier") {
     } else if (name == "wait") {
     } else {

--- a/src/qx/circuit_builder.cpp
+++ b/src/qx/circuit_builder.cpp
@@ -101,6 +101,9 @@ void CircuitBuilder::visit_non_gate_instruction(CqasmV3xNonGateInstruction& non_
                 circuit_.add_instruction(std::make_shared<Reset>(qubit_index));
             }
         }
+    } else if (name == "init") {
+    } else if (name == "barrier") {
+    } else if (name == "wait") {
     } else {
         throw CircuitBuilderError{ fmt::format("unsupported non-gate instruction: '{}'", name) };
     }

--- a/src/qx/instructions.cpp
+++ b/src/qx/instructions.cpp
@@ -16,6 +16,14 @@ void BitControlledInstruction::execute(SimulationIterationContext& context) {
     }
 }
 
+[[nodiscard]] qubit_indices_t BitControlledInstruction::get_qubit_indices() {
+    return instruction->get_qubit_indices();
+}
+
+[[nodiscard]] bit_indices_t BitControlledInstruction::get_bit_indices() {
+    return instruction->get_bit_indices();
+}
+
 Unitary::Unitary(std::shared_ptr<core::matrix_t> matrix, std::shared_ptr<core::operands_t> operands)
 : matrix{ std::move(matrix) }
 , operands{ std::move(operands) } {}
@@ -36,6 +44,18 @@ void Unitary::execute(SimulationIterationContext& context) {
     return std::make_shared<core::matrix_t>(matrix->control());
 }
 
+[[nodiscard]] qubit_indices_t Unitary::get_qubit_indices() {
+    return *operands;
+}
+
+[[nodiscard]] bit_indices_t Unitary::get_bit_indices() {
+    return bit_indices_t{};
+}
+
+[[nodiscard]] qubit_indices_t Measure::get_qubit_indices() {
+    return qubit_indices_t{ qubit_index };
+}
+
 Measure::Measure(const core::QubitIndex& qubit_index, const core::BitIndex& bit_index)
 : qubit_index{ qubit_index }
 , bit_index{ bit_index } {}
@@ -48,6 +68,10 @@ void Measure::execute(SimulationIterationContext& context) {
         context.bit_measurement_register);
 }
 
+[[nodiscard]] bit_indices_t Measure::get_bit_indices() {
+    return bit_indices_t{ bit_index };
+}
+
 Reset::Reset(std::optional<core::QubitIndex> qubit_index)
 : qubit_index{ qubit_index } {}
 
@@ -57,6 +81,14 @@ void Reset::execute(SimulationIterationContext& context) {
     } else {
         context.state.apply_reset_all();
     }
+}
+
+[[nodiscard]] qubit_indices_t Reset::get_qubit_indices() {
+    return qubit_index.has_value() ? qubit_indices_t{ *qubit_index } : qubit_indices_t{};
+}
+
+[[nodiscard]] bit_indices_t Reset::get_bit_indices() {
+    return bit_indices_t{};
 }
 
 }  // namespace qx

--- a/src/qx/register_manager.cpp
+++ b/src/qx/register_manager.cpp
@@ -38,6 +38,7 @@ Register::Register(const TreeOne<CqasmV3xProgram>& program, auto&& is_of_type, s
 
     variable_name_to_range_.reserve(register_size_);
     index_to_variable_name_.resize(register_size_);
+    dirty_bitset_ = DirtyBitsetT{ register_size_ };
 
     auto current_index = size_t{};
     for (auto&& variable : variables) {
@@ -65,7 +66,7 @@ Register::~Register() = default;
     return range.first + sub_index.value_or(0);
 }
 
-[[nodiscard]] VariableName Register::at(const std::size_t& index) const {
+[[nodiscard]] VariableName Register::at(const Index& index) const {
     return index_to_variable_name_.at(index);
 }
 
@@ -79,6 +80,16 @@ Register::~Register() = default;
         });
     return fmt::format("{{ {0} }}", entries);
 }
+
+[[nodiscard]] bool Register::is_dirty(const Index& index) const {
+    return dirty_bitset_[index];
+}
+
+void Register::set_dirty(const Index& index) {
+    assert(index < register_size_);
+    dirty_bitset_[index] = 1;
+}
+
 
 //---------------//
 // QubitRegister //
@@ -155,12 +166,43 @@ BitRegister::~BitRegister() = default;
     return bit_register_->at(index);
 }
 
+[[nodiscard]] Index RegisterManager::get_qubit_variable_index(const Index& index) const {
+    const auto& variable_name = qubit_register_->at(index);
+    const auto& first_index = qubit_register_->at(variable_name).first;
+    assert(index >= first_index);
+    return index - first_index;
+}
+
+[[nodiscard]] Index RegisterManager::get_bit_variable_index(const Index& index) const {
+    const auto& variable_name = bit_register_->at(index);
+    const auto& first_index = bit_register_->at(variable_name).first;
+    assert(index >= first_index);
+    return index - first_index;
+}
+
+
 [[nodiscard]] std::shared_ptr<QubitRegister> RegisterManager::get_qubit_register() const {
     return qubit_register_;
 }
 
 [[nodiscard]] std::shared_ptr<BitRegister> RegisterManager::get_bit_register() const {
     return bit_register_;
+}
+
+[[nodiscard]] bool RegisterManager::is_dirty_qubit(const Index& index) const {
+    return qubit_register_->is_dirty(index);
+}
+
+[[nodiscard]] bool RegisterManager::is_dirty_bit(const Index& index) const {
+    return bit_register_->is_dirty(index);
+}
+
+void RegisterManager::set_dirty_qubit(const Index& index) {
+    qubit_register_->set_dirty(index);
+}
+
+void RegisterManager::set_dirty_bit(const Index& index) {
+    qubit_register_->set_dirty(index);
 }
 
 std::ostream& operator<<(std::ostream& os, const Range& range) {

--- a/src/qx/register_manager.cpp
+++ b/src/qx/register_manager.cpp
@@ -87,9 +87,8 @@ Register::~Register() = default;
 
 void Register::set_dirty(const Index& index) {
     assert(index < register_size_);
-    dirty_bitset_[index] = 1;
+    dirty_bitset_[index] = true;
 }
-
 
 //---------------//
 // QubitRegister //
@@ -179,7 +178,6 @@ BitRegister::~BitRegister() = default;
     assert(index >= first_index);
     return index - first_index;
 }
-
 
 [[nodiscard]] std::shared_ptr<QubitRegister> RegisterManager::get_qubit_register() const {
     return qubit_register_;

--- a/test/integration_test.cpp
+++ b/test/integration_test.cpp
@@ -1,8 +1,9 @@
-#include <gmock/gmock.h>
+#include <gmock/gmock.h>  // ThrowsMessage
 #include <gtest/gtest.h>
 
 #include <cmath>  // abs
 #include <optional>  // nullopt
+#include <stdexcept>  // runtime_error
 
 #include "qx/simulator.hpp"
 
@@ -19,7 +20,7 @@ public:
 };
 
 TEST_F(IntegrationTest, bell_pair) {
-    auto cqasm = R"(
+    auto program = R"(
 version 3.0
 
 qubit[2] q
@@ -28,7 +29,7 @@ H q[0]
 CNOT q[0], q[1]
 )";
     std::size_t iterations = 1;
-    auto actual = run_from_string(cqasm, iterations, "3.0");
+    auto actual = run_from_string(program, iterations, "3.0");
 
     EXPECT_EQ(actual.shots_requested, iterations);
     EXPECT_EQ(actual.shots_done, iterations);
@@ -43,7 +44,7 @@ CNOT q[0], q[1]
 }
 
 TEST_F(IntegrationTest, range_operands) {
-    auto cqasm = R"(
+    auto program = R"(
 version 3.0
 
 qubit[6] q
@@ -51,7 +52,7 @@ X q[0:2]
 CNOT q[0:2], q[3:5]
 )";
     std::size_t iterations = 2;
-    auto actual = run_from_string(cqasm, iterations);
+    auto actual = run_from_string(program, iterations);
 
     // Expected 'q' state should be |111111>
     EXPECT_EQ(actual.state,
@@ -70,7 +71,7 @@ TEST_F(IntegrationTest, too_many_qubits) {
 }
 
 TEST_F(IntegrationTest, syntax_error) {
-    auto cqasm = R"(
+    auto program = R"(
 version 3.0
 
 qubit q
@@ -78,7 +79,7 @@ qubit q
 H q[0
 )";
 
-    auto result = execute_string(cqasm);
+    auto result = execute_string(program);
     auto message = std::string{ std::get_if<SimulationError>(&result)->what() };
     EXPECT_TRUE(std::holds_alternative<SimulationError>(result));
     EXPECT_THAT(message, ::testing::StartsWith(R"(cQASM v3 analyzer returned errors:
@@ -86,7 +87,7 @@ Error at <unknown file name>:6:6..7: missing ']' at '\n')"));
 }
 
 TEST_F(IntegrationTest, identity) {
-    auto cqasm = R"(
+    auto program = R"(
 version 3.0
 
 qubit[2] q
@@ -97,7 +98,7 @@ CNOT q[0], q[1]
 I q[1]
 )";
     std::size_t iterations = 1;
-    auto actual = run_from_string(cqasm, iterations, "3.0");
+    auto actual = run_from_string(program, iterations, "3.0");
 
     EXPECT_EQ(actual.shots_requested, iterations);
     EXPECT_EQ(actual.shots_done, iterations);
@@ -113,7 +114,7 @@ I q[1]
 }
 
 TEST_F(IntegrationTest, swap) {
-    auto cqasm = R"(
+    auto program = R"(
 version 3.0
 
 qubit[2] q
@@ -123,7 +124,7 @@ CZ q[0], q[1]
 SWAP q[0], q[1]
 )";
     std::size_t iterations = 1;
-    auto actual = run_from_string(cqasm, iterations, "3.0");
+    auto actual = run_from_string(program, iterations, "3.0");
 
     // Expected 'q' state should be |00>-|10> after SWAP
     // State is |00>+|01> after H, then CZ just flips the phase of the |01> term,
@@ -136,7 +137,7 @@ SWAP q[0], q[1]
 }
 
 TEST_F(IntegrationTest, measure) {
-    auto cqasm = R"(
+    auto program = R"(
 version 3.0
 
 qubit[3] q
@@ -149,7 +150,7 @@ CNOT q[1], q[2]
 b = measure q
 )";
     std::size_t iterations = 10'000;
-    auto actual = run_from_string(cqasm, iterations);
+    auto actual = run_from_string(program, iterations);
 
     // Expected 'q' state should be |001> or |111>
     EXPECT_TRUE(actual.state[0].value.ends_with('1'));
@@ -165,7 +166,7 @@ b = measure q
 }
 
 TEST_F(IntegrationTest, multiple_measure_instructions) {
-    auto cqasm = R"(
+    auto program = R"(
 version 3.0
 
 qubit[3] q
@@ -180,7 +181,7 @@ b[1] = measure q[1]
 b[2] = measure q[2]
 )";
     std::size_t iterations = 10'000;
-    auto actual = run_from_string(cqasm, iterations);
+    auto actual = run_from_string(program, iterations);
 
     // Expected 'q' state should be |001> or |111>
     EXPECT_TRUE(actual.state[0].value.ends_with('1'));
@@ -196,7 +197,7 @@ b[2] = measure q[2]
 }
 
 TEST_F(IntegrationTest, mid_circuit_measure_instruction) {
-    auto cqasm = R"(
+    auto program = R"(
 version 3.0
 
 qubit[2] q
@@ -210,7 +211,7 @@ CNOT q[1], q[0]
 b = measure q
 )";
     std::size_t iterations = 10'000;
-    auto actual = run_from_string(cqasm, iterations);
+    auto actual = run_from_string(program, iterations);
 
     // Expected 'q' state should be |00>+|11> or |01>+|10>
     auto error = static_cast<std::uint64_t>(static_cast<double>(iterations) / 2 * 0.05);
@@ -222,7 +223,7 @@ b = measure q
 }
 
 TEST_F(IntegrationTest, multiple_qubit_bit_definitions_and_mid_circuit_measure_instructions) {
-    auto cqasm = R"(
+    auto program = R"(
 version 3.0
 
 qubit q0
@@ -238,7 +239,7 @@ b0 = measure q0
 b1 = measure q1
 )";
     std::size_t iterations = 10'000;
-    auto actual = run_from_string(cqasm, iterations);
+    auto actual = run_from_string(program, iterations);
 
     // Expected q1-q0 state should be |00>+|11> or |01>+|10>
     auto error = static_cast<std::uint64_t>(static_cast<double>(iterations) / 2 * 0.05);
@@ -250,7 +251,7 @@ b1 = measure q1
 }
 
 TEST_F(IntegrationTest, reset__x_measure_reset) {
-    auto cqasm = R"(
+    auto program = R"(
 version 3.0
 
 qubit q
@@ -260,7 +261,7 @@ b = measure q
 reset q
 )";
     std::size_t iterations = 10'000;
-    auto actual = run_from_string(cqasm, iterations);
+    auto actual = run_from_string(program, iterations);
 
     // Expected 'q' state should always be |0> because 'reset' modifies the qubit state
     EXPECT_EQ(actual.state[0].value, "0");
@@ -274,7 +275,7 @@ reset q
 
 TEST_F(IntegrationTest, reset__bell_state_then_reset) {
     std::size_t iterations = 10'000;
-    auto cqasm = R"(
+    auto program = R"(
 version 3.0
 
 qubit[2] q
@@ -283,7 +284,7 @@ H q[0]
 CNOT q[0], q[1]
 reset q[0]
 )";
-    auto actual = run_from_string(cqasm, iterations);
+    auto actual = run_from_string(program, iterations);
 
     // Expected 'q' state should be |00>+|10>
     // State is |00>+|11> after creating the Bell state
@@ -297,7 +298,7 @@ reset q[0]
 
 TEST_F(IntegrationTest, reset__bell_state_then_reset_and_measure) {
     std::size_t iterations = 10'000;
-    auto cqasm = R"(
+    auto program = R"(
 version 3.0
 
 qubit[2] q
@@ -307,7 +308,7 @@ CNOT q[0], q[1]
 reset q[0]
 b = measure q
 )";
-    auto actual = run_from_string(cqasm, iterations);
+    auto actual = run_from_string(program, iterations);
 
     // Expected 'q' state should be |00>+|10>
     // State is |00>+|11> after creating the Bell state
@@ -325,7 +326,7 @@ b = measure q
 
 TEST_F(IntegrationTest, reset__bell_state_then_measure_and_reset) {
     std::size_t iterations = 10'000;
-    auto cqasm = R"(
+    auto program = R"(
 version 3.0
 
 qubit[2] q
@@ -335,7 +336,7 @@ CNOT q[0], q[1]
 b = measure q
 reset q[0]
 )";
-    auto actual = run_from_string(cqasm, iterations);
+    auto actual = run_from_string(program, iterations);
 
     // Expected 'q' state should be |00> or |10>
     // State is |00>+|11> after creating the Bell state
@@ -354,7 +355,7 @@ reset q[0]
 }
 
 TEST_F(IntegrationTest, bit_measurement_register) {
-    auto cqasm = R"(
+    auto program = R"(
 version 3.0
 
 qubit[2] qq
@@ -369,7 +370,7 @@ bit b
 b = measure qq[0]
 )";
     std::size_t iterations = 10'000;
-    auto actual = run_from_string(cqasm, iterations);
+    auto actual = run_from_string(program, iterations);
 
     // Expected bb[0] value should always be '1'
     // Expected 'b' value should be '0' 50% of the cases and '1' 50% of the cases
@@ -381,8 +382,50 @@ b = measure qq[0]
     }
 }
 
+TEST_F(IntegrationTest, correct_init_is_just_discarded_by_the_simulator) {
+    auto program = R"(
+version 3.0
+
+qubit[2] q
+
+init q[0]
+H q[0]
+barrier q[1]
+init q[1]
+CNOT q[0], q[1]
+)";
+    std::size_t iterations = 1;
+    auto actual = run_from_string(program, iterations, "3.0");
+
+    // Expected 'q' state should be |00>+|10>
+    // State is |00>+|11> after creating the Bell state
+    // A correct 'init' instruction is discarded by the simulator
+    EXPECT_EQ(actual.state,
+        (SimulationResult::State{
+            { "00", core::Complex{ .real = 1 / std::sqrt(2), .imag = 0, .norm = 0.5 } },
+            { "11", core::Complex{ .real = 1 / std::sqrt(2), .imag = 0, .norm = 0.5 } }
+    }));
+}
+
+TEST_F(IntegrationTest, incorrect_init_throws_error) {
+    auto program = R"(
+version 3.0
+
+qubit[2] qq
+
+H qq[0]
+CNOT qq[0], qq[1]
+init qq[0]
+)";
+    auto result = execute_string(program);
+    auto message = std::string{ std::get_if<SimulationError>(&result)->what() };
+    EXPECT_TRUE(std::holds_alternative<SimulationError>(result));
+    EXPECT_EQ(message, "trying to 'init qq[0]' but qubit is not in ground state");
+
+}
+
 TEST_F(IntegrationTest, barrier_and_wait_are_just_discarded_by_the_simulator) {
-    auto cqasm = R"(
+    auto program = R"(
 version 3.0
 
 qubit[2] q
@@ -397,10 +440,7 @@ barrier q[1]
 wait(2) q
 )";
     std::size_t iterations = 1;
-    auto actual = run_from_string(cqasm, iterations, "3.0");
-
-    EXPECT_EQ(actual.shots_requested, iterations);
-    EXPECT_EQ(actual.shots_done, iterations);
+    auto actual = run_from_string(program, iterations, "3.0");
 
     // Expected 'q' state should be |00>+|11>
     // State is |00>+|11> after creating the Bell state
@@ -413,7 +453,7 @@ wait(2) q
 }
 
 TEST_F(IntegrationTest, inverse_gate_modifier__inv_inv) {
-    auto cqasm = R"(
+    auto program = R"(
 version 3.0
 
 qubit q
@@ -421,7 +461,7 @@ qubit q
 inv.inv.H q
 )";
     std::size_t iterations = 10'000;
-    auto actual = run_from_string(cqasm, iterations);
+    auto actual = run_from_string(program, iterations);
 
     // Expected 'q' state should be |0>+|1> as inv.inv.H is equivalent to H
     EXPECT_EQ(actual.state,
@@ -432,7 +472,7 @@ inv.inv.H q
 }
 
 TEST_F(IntegrationTest, power_gate_modifier__pow_2_s) {
-    auto cqasm = R"(
+    auto program = R"(
 version 3.0
 
 qubit q
@@ -440,7 +480,7 @@ qubit q
 pow(2).X q
 )";
     std::size_t iterations = 10'000;
-    auto actual = run_from_string(cqasm, iterations);
+    auto actual = run_from_string(program, iterations);
 
     // Expected 'q' state should be |0> as pow(2).X is equivalent to I
     EXPECT_EQ(actual.state,
@@ -450,7 +490,7 @@ pow(2).X q
 }
 
 TEST_F(IntegrationTest, control_gate_modifier__ctrl_x) {
-    auto cqasm = R"(
+    auto program = R"(
 version 3.0
 
 qubit[2] q
@@ -459,7 +499,7 @@ H q[0]
 ctrl.X q[0], q[1]
 )";
     std::size_t iterations = 1;
-    auto actual = run_from_string(cqasm, iterations, "3.0");
+    auto actual = run_from_string(program, iterations, "3.0");
 
     // Expected 'q' state should be |00>+|11> as ctrl.X is equivalent to CNOT
     // State is |00>+|11> after creating the Bell state
@@ -471,7 +511,7 @@ ctrl.X q[0], q[1]
 }
 
 TEST_F(IntegrationTest, gate_modifier__ctrl_pow_2_s) {
-    auto cqasm = R"(
+    auto program = R"(
 version 3.0
 
 qubit[2] q
@@ -480,7 +520,7 @@ H q[0]
 ctrl.pow(2).S q[0], q[1]
 )";
     std::size_t iterations = 1;
-    auto actual = run_from_string(cqasm, iterations, "3.0");
+    auto actual = run_from_string(program, iterations, "3.0");
 
     // Expected 'q' state should be |00>-|01> as ctrl.pow(2).S is equivalent to CZ
     // State is |00>+|01> after H, then CZ just flips the phase of the |01> term

--- a/test/integration_test.cpp
+++ b/test/integration_test.cpp
@@ -33,7 +33,7 @@ CNOT q[0], q[1]
     EXPECT_EQ(actual.shots_requested, iterations);
     EXPECT_EQ(actual.shots_done, iterations);
 
-    // Expected q state should be |00>+|11>
+    // Expected 'q' state should be |00>+|11>
     // State is |00>+|11> after creating the Bell state
     EXPECT_EQ(actual.state,
         (SimulationResult::State{
@@ -53,7 +53,7 @@ CNOT q[0:2], q[3:5]
     std::size_t iterations = 2;
     auto actual = run_from_string(cqasm, iterations);
 
-    // Expected q state should be |111111>
+    // Expected 'q' state should be |111111>
     EXPECT_EQ(actual.state,
         (SimulationResult::State{
             { "111111", core::Complex{ .real = 1, .imag = 0, .norm = 1 } }
@@ -102,7 +102,7 @@ I q[1]
     EXPECT_EQ(actual.shots_requested, iterations);
     EXPECT_EQ(actual.shots_done, iterations);
 
-    // Expected q state should be |00>+|11>
+    // Expected 'q' state should be |00>+|11>
     // State is |00>+|11> after creating the Bell state
     // Identity gates do not modify the state of the qubits
     EXPECT_EQ(actual.state,
@@ -125,7 +125,7 @@ SWAP q[0], q[1]
     std::size_t iterations = 1;
     auto actual = run_from_string(cqasm, iterations, "3.0");
 
-    // Expected q state should be |00>-|10> after SWAP
+    // Expected 'q' state should be |00>-|10> after SWAP
     // State is |00>+|01> after H, then CZ just flips the phase of the |01> term,
     // and SWAP exchanges states for qubits 0 and 1
     EXPECT_EQ(actual.state,
@@ -151,11 +151,11 @@ b = measure q
     std::size_t iterations = 10'000;
     auto actual = run_from_string(cqasm, iterations);
 
-    // Expected q state should be |001> or |111>
+    // Expected 'q' state should be |001> or |111>
     EXPECT_TRUE(actual.state[0].value.ends_with('1'));
     EXPECT_EQ(actual.state[0].amplitude, (core::Complex{ .real = 1, .imag = 0, .norm = 1 }));
 
-    // Expected b value should be "001" 50% of the cases and "111" 50% of the cases
+    // Expected 'b' value should be "001" 50% of the cases and "111" 50% of the cases
     auto error = static_cast<std::uint64_t>(static_cast<double>(iterations) / 2 * 0.05);
     EXPECT_EQ(actual.measurements.size(), 2);
     EXPECT_EQ(actual.measurements[0].state, "001");
@@ -182,11 +182,11 @@ b[2] = measure q[2]
     std::size_t iterations = 10'000;
     auto actual = run_from_string(cqasm, iterations);
 
-    // Expected q state should be |001> or |111>
+    // Expected 'q' state should be |001> or |111>
     EXPECT_TRUE(actual.state[0].value.ends_with('1'));
     EXPECT_EQ(actual.state[0].amplitude, (core::Complex{ .real = 1, .imag = 0, .norm = 1 }));
 
-    // Expected b value should be "001" 50% of the cases and "111" 50% of the cases
+    // Expected 'b' value should be "001" 50% of the cases and "111" 50% of the cases
     auto error = static_cast<std::uint64_t>(static_cast<double>(iterations) / 2 * 0.05);
     EXPECT_EQ(actual.measurements.size(), 2);
     EXPECT_EQ(actual.measurements[0].state, "001");
@@ -212,7 +212,7 @@ b = measure q
     std::size_t iterations = 10'000;
     auto actual = run_from_string(cqasm, iterations);
 
-    // Expected q state should be |00>+|11> or |01>+|10>
+    // Expected 'q' state should be |00>+|11> or |01>+|10>
     auto error = static_cast<std::uint64_t>(static_cast<double>(iterations) / 2 * 0.05);
     EXPECT_EQ(actual.measurements.size(), 2);
     EXPECT_TRUE(actual.measurements[0].state == "00" || actual.measurements[0].state == "01");
@@ -262,11 +262,11 @@ reset q
     std::size_t iterations = 10'000;
     auto actual = run_from_string(cqasm, iterations);
 
-    // Expected q state should always be |0> because reset modifies the qubit state
+    // Expected 'q' state should always be |0> because 'reset' modifies the qubit state
     EXPECT_EQ(actual.state[0].value, "0");
     EXPECT_EQ(actual.state[0].amplitude, (core::Complex{ .real = 1, .imag = 0, .norm = 1 }));
 
-    // Expected b value should always be "1" because reset does not modify the measurement register
+    // Expected 'b' value should always be '1' because 'reset' does not modify the measurement register
     EXPECT_EQ(actual.measurements.size(), 1);
     EXPECT_TRUE(actual.measurements[0].state == "1");
     EXPECT_EQ(actual.measurements[0].count, iterations);
@@ -285,9 +285,9 @@ reset q[0]
 )";
     auto actual = run_from_string(cqasm, iterations);
 
-    // Expected q state should be |00>+|10>
+    // Expected 'q' state should be |00>+|10>
     // State is |00>+|11> after creating the Bell state
-    // Then reset sets q to |0>, leaving the state as |00>+|10>
+    // Then 'reset' sets q to |0>, leaving the state as |00>+|10>
     EXPECT_EQ(actual.state,
         (SimulationResult::State{
             { "00", core::Complex{ .real = 1 / std::sqrt(2), .imag = 0, .norm = 0.5 } },
@@ -309,10 +309,10 @@ b = measure q
 )";
     auto actual = run_from_string(cqasm, iterations);
 
-    // Expected q state should be |00>+|10>
+    // Expected 'q' state should be |00>+|10>
     // State is |00>+|11> after creating the Bell state
-    // Then reset sets q to |0>, leaving the state as |00>+|10>
-    // The measure provokes a collapse of the state to either |00> or |10>
+    // Then 'reset' sets q to |0>, leaving the state as |00>+|10>
+    // 'measure' provokes a collapse of the state to either |00> or |10>
     EXPECT_TRUE(actual.state[0].value.ends_with('0'));
     EXPECT_EQ(actual.state[0].amplitude, (core::Complex{ .real = 1, .imag = 0, .norm = 1 }));
 
@@ -337,16 +337,16 @@ reset q[0]
 )";
     auto actual = run_from_string(cqasm, iterations);
 
-    // Expected q state should be |00> or |10>
+    // Expected 'q' state should be |00> or |10>
     // State is |00>+|11> after creating the Bell state
-    // The measure provokes a collapse of the state to either |00> or |11>
-    // Then reset sets q0 to |0>, leaving the state as |00> or |10>
+    // 'measure' provokes a collapse of the state to either |00> or |11>
+    // Then 'reset' sets q0 to |0>, leaving the state as |00> or |10>
     EXPECT_TRUE(actual.state[0].value.ends_with('0'));
     EXPECT_EQ(actual.state[0].amplitude, (core::Complex{ .real = 1, .imag = 0, .norm = 1 }));
 
-    // Expected b value should be "00" 50% of the cases and "11" 50% of the cases
-    // because the measure happens right after creating the Bell state,
-    // and reset does not modify the measurement register
+    // Expected 'b' value should be '00' 50% of the cases and '11' 50% of the cases
+    // because 'measure' happens right after creating the Bell state,
+    // and 'reset' does not modify the measurement register
     auto error = static_cast<std::uint64_t>(static_cast<double>(iterations) / 2 * 0.05);
     EXPECT_EQ(actual.measurements.size(), 2);
     EXPECT_TRUE(actual.measurements[0].state == "00" || actual.measurements[0].state == "11");
@@ -371,8 +371,8 @@ b = measure qq[0]
     std::size_t iterations = 10'000;
     auto actual = run_from_string(cqasm, iterations);
 
-    // Expected bb[0] value should always be "1"
-    // Expected b value should be "0" 50% of the cases and "1" 50% of the cases
+    // Expected bb[0] value should always be '1'
+    // Expected 'b' value should be '0' 50% of the cases and '1' 50% of the cases
     auto error = static_cast<std::uint64_t>(static_cast<double>(iterations) / 2 * 0.05);
     EXPECT_EQ(actual.bit_measurements.size(), 2);
     for (const auto& bit_measurement : actual.bit_measurements) {
@@ -402,9 +402,9 @@ wait(2) q
     EXPECT_EQ(actual.shots_requested, iterations);
     EXPECT_EQ(actual.shots_done, iterations);
 
-    // Expected q state should be |00>+|11>
+    // Expected 'q' state should be |00>+|11>
     // State is |00>+|11> after creating the Bell state
-    // barrier and wait instructions are just discarded by the simulator
+    // 'barrier' and 'wait' instructions are just discarded by the simulator
     EXPECT_EQ(actual.state,
         (SimulationResult::State{
             { "00", core::Complex{ .real = 1 / std::sqrt(2), .imag = 0, .norm = 0.5 } },
@@ -423,7 +423,7 @@ inv.inv.H q
     std::size_t iterations = 10'000;
     auto actual = run_from_string(cqasm, iterations);
 
-    // Expected q state should be |0>+|1> as inv.inv.H is equivalent to H
+    // Expected 'q' state should be |0>+|1> as inv.inv.H is equivalent to H
     EXPECT_EQ(actual.state,
         (SimulationResult::State{
             { "0", core::Complex{ .real = 1 / std::sqrt(2), .imag = 0, .norm = 0.5 } },
@@ -442,7 +442,7 @@ pow(2).X q
     std::size_t iterations = 10'000;
     auto actual = run_from_string(cqasm, iterations);
 
-    // Expected q state should be |0> as pow(2).X is equivalent to I
+    // Expected 'q' state should be |0> as pow(2).X is equivalent to I
     EXPECT_EQ(actual.state,
         (SimulationResult::State{
             { "0", core::Complex{ .real = 1, .imag = 0, .norm = 1 } }
@@ -461,7 +461,7 @@ ctrl.X q[0], q[1]
     std::size_t iterations = 1;
     auto actual = run_from_string(cqasm, iterations, "3.0");
 
-    // Expected q state should be |00>+|11> as ctrl.X is equivalent to CNOT
+    // Expected 'q' state should be |00>+|11> as ctrl.X is equivalent to CNOT
     // State is |00>+|11> after creating the Bell state
     EXPECT_EQ(actual.state,
         (SimulationResult::State{
@@ -482,7 +482,7 @@ ctrl.pow(2).S q[0], q[1]
     std::size_t iterations = 1;
     auto actual = run_from_string(cqasm, iterations, "3.0");
 
-    // Expected q state should be |00>-|01> as ctrl.pow(2).S is equivalent to CZ
+    // Expected 'q' state should be |00>-|01> as ctrl.pow(2).S is equivalent to CZ
     // State is |00>+|01> after H, then CZ just flips the phase of the |01> term
     EXPECT_EQ(actual.state,
         (SimulationResult::State{

--- a/test/integration_test.cpp
+++ b/test/integration_test.cpp
@@ -421,7 +421,6 @@ init qq[0]
     auto message = std::string{ std::get_if<SimulationError>(&result)->what() };
     EXPECT_TRUE(std::holds_alternative<SimulationError>(result));
     EXPECT_EQ(message, "trying to 'init qq[0]' but qubit is not in ground state");
-
 }
 
 TEST_F(IntegrationTest, barrier_and_wait_are_just_discarded_by_the_simulator) {


### PR DESCRIPTION
Update the simulator to correctly work with libQASM 0.6.9.

libQASM 0.6.9 adds:
- `SWAP` gate instruction. Which is already implemented in QX simulator.
- `barrier`, `wait`, and `init` non-gate instructions.

The register manager now holds a 'dirty bitset' for virtual qubit and bit indices:
- All instructions added to the circuit set dirty flags for each qubit operand.
- Notice 'barrier', 'wait', and 'init' are not added to the circuit.
- 'init' instructions throw if they are performed on a 'dirty' qubit.

`wait` instructions throw if they time parameter is negative.