### PR TITLE
Creating release 0.7.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - **Removed** for now removed features.
 
 
-## [ 0.7.4 ] - [ xxxx-yy-zz ]
+## [ 0.7.4 ] - [ 2025-01-29 ]
 
 ### Added
 - Integrate with libqasm 0.6.9 release:

--- a/include/qx/version.hpp
+++ b/include/qx/version.hpp
@@ -1,4 +1,4 @@
 #ifndef QX_VERSION
-#define QX_VERSION "0.7.3"
-#define QX_RELEASE_YEAR "2024"
+#define QX_VERSION "0.7.4"
+#define QX_RELEASE_YEAR "2025"
 #endif


### PR DESCRIPTION
### Added
- Integrate with libqasm 0.6.9 release:
    - Add `SWAP` gate instruction.
    - Add `barrier`, `wait`, and `ìnit` non-gate instructions.
- The register manager now holds a 'dirty bitset' for virtual qubit and bit indices.