### PR TITLE
Add `doc` workflow

### DIFF
--- a/.github/workflows/doc.yaml
+++ b/.github/workflows/doc.yaml
@@ -1,0 +1,50 @@
+name: Doc
+
+on:
+  pull_request:
+  push:
+    branches:
+      - develop
+      - master
+  release:
+    types:
+      - created
+
+jobs:
+  publish-github-pages:
+    name: Publish GitHub pages
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install dependencies
+        run: |
+          sudo apt-get install -y doxygen
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip -r requirements.txt
+      - name: Configure Git
+        run: |
+          git config --global user.name "${{ github.actor }}"
+          git config --global user.email "${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com"
+          git fetch origin gh-pages:gh-pages
+      - name: Add mkdocs custom handlers folder to env
+        run: |
+          echo "PYTHONPATH=./scripts/python" >> $GITHUB_ENV
+      - name: Dry run
+        if: github.event_name == 'pull_request'
+        run: |          
+          mkdocs build
+      - name: Upload and tag as latest with every push to develop branch
+        if: github.ref == 'refs/heads/develop'
+        run: |
+          mike deploy --push latest
+          mike set-default --push latest
+      - name: Upload and tag as git tag with every release creation on master branch
+        if: github.event_name == 'release' && github.event.action == 'created'
+        run: |
+          mike deploy --push ${{ github.ref_name }}
+          mike set-default --push latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - **Removed** for now removed features.
 
 
+## [ 0.7.5 ] - [ xxxx-yy-zz ]
+
+### Added
+- Documentation: GitHub Actions `doc` workflow.
+
+
 ## [ 0.7.4 ] - [ 2025-01-29 ]
 
 ### Added

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+mike==2.1.2
+mkdocs-material==9.5.29
+mkdocstrings==0.25.1
+pymdown-extensions==10.8.1


### PR DESCRIPTION
I have just  noticed this wasn't added when we added the documentation framework (QX/0.7.3).

We need a `doc` GitHub Actions workflow to build and publish an updated documentation.