### PR TITLE
[CQT-321] Optimizations to `DenseUnitaryMatrix` and default gates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Documentation: GitHub Actions `doc` workflow.
 
+### Changed
+- Allow move constructing a `DenseUnitaryMatrix`.
+
 ### Removed
 - Support for 'reset all'.
 

--- a/include/qx/dense_unitary_matrix.hpp
+++ b/include/qx/dense_unitary_matrix.hpp
@@ -19,6 +19,7 @@ using Matrix = std::vector<Row>;
 
 class DenseUnitaryMatrix {
 public:
+    ~DenseUnitaryMatrix() = default;
     DenseUnitaryMatrix(const DenseUnitaryMatrix& other) = default;
     DenseUnitaryMatrix(DenseUnitaryMatrix&& other) noexcept = default;
     DenseUnitaryMatrix& operator=(const DenseUnitaryMatrix& other) = default;

--- a/include/qx/dense_unitary_matrix.hpp
+++ b/include/qx/dense_unitary_matrix.hpp
@@ -19,7 +19,14 @@ using Matrix = std::vector<Row>;
 
 class DenseUnitaryMatrix {
 public:
-    explicit DenseUnitaryMatrix(const Matrix& m);
+    DenseUnitaryMatrix(const DenseUnitaryMatrix& other) = default;
+    DenseUnitaryMatrix(DenseUnitaryMatrix&& other) noexcept = default;
+    DenseUnitaryMatrix& operator=(const DenseUnitaryMatrix& other) = default;
+    DenseUnitaryMatrix& operator=(DenseUnitaryMatrix&& other) noexcept = default;
+
+public:
+    explicit DenseUnitaryMatrix(const Matrix& matrix, bool is_unitary_check = true);
+    explicit DenseUnitaryMatrix(Matrix&& matrix, bool is_unitary_check = true);
 
     [[nodiscard]] std::complex<double>& at(std::size_t i, std::size_t j);
     [[nodiscard]] const std::complex<double>& at(std::size_t i, std::size_t j) const;
@@ -36,11 +43,13 @@ public:
     [[nodiscard]] DenseUnitaryMatrix control() const;
 
 private:
-    DenseUnitaryMatrix(const Matrix& m, bool is_unitary_check);
+    DenseUnitaryMatrix() = default;
+
+private:
     void check_is_unitary() const;
     void check_is_square() const;
 
-    Matrix matrix;
+    Matrix matrix_;
     size_t N;  // matrix size
 };
 

--- a/include/qx/gates.hpp
+++ b/include/qx/gates.hpp
@@ -20,9 +20,9 @@ using namespace std::complex_literals;  // i
 inline constexpr long double PI = std::numbers::pi_v<long double>;
 inline constexpr double SQRT_2 = std::numbers::sqrt2_v<long double>;
 
-inline static UnitaryMatrix IDENTITY = UnitaryMatrix::identity(2);
+static UnitaryMatrix IDENTITY = UnitaryMatrix::identity(2);
 
-inline static UnitaryMatrix X{
+static UnitaryMatrix X{
     Matrix{
         { 0, 1 },
         { 1, 0 }
@@ -30,7 +30,7 @@ inline static UnitaryMatrix X{
     false
 };
 
-inline static UnitaryMatrix Y{
+static UnitaryMatrix Y{
     Matrix{
         {  0, -1i },
         { 1i,   0 }
@@ -38,7 +38,7 @@ inline static UnitaryMatrix Y{
     false
 };
 
-inline static UnitaryMatrix Z{
+static UnitaryMatrix Z{
     Matrix{
         { 1,  0 },
         { 0, -1 }
@@ -46,7 +46,7 @@ inline static UnitaryMatrix Z{
     false
 };
 
-inline static UnitaryMatrix S{
+static UnitaryMatrix S{
     Matrix{
         { 1,  0 },
         { 0, 1i }
@@ -54,9 +54,9 @@ inline static UnitaryMatrix S{
     false
 };
 
-inline static UnitaryMatrix SDAG = S.dagger();
+static UnitaryMatrix SDAG = S.dagger();
 
-inline static UnitaryMatrix T{
+static UnitaryMatrix T{
     Matrix{
         { 1,                        0 },
         { 0, 1 / SQRT_2 + 1i / SQRT_2 }
@@ -64,9 +64,9 @@ inline static UnitaryMatrix T{
     false
 };
 
-inline static UnitaryMatrix TDAG = T.dagger();
+static UnitaryMatrix TDAG = T.dagger();
 
-inline static UnitaryMatrix RX(double theta) {
+inline UnitaryMatrix RX(double theta) {
     return UnitaryMatrix{
         Matrix{
             {       std::cos(theta / 2), -1i * std::sin(theta / 2) },
@@ -76,7 +76,7 @@ inline static UnitaryMatrix RX(double theta) {
     };
 }
 
-inline static UnitaryMatrix RY(double theta) {
+inline UnitaryMatrix RY(double theta) {
     return UnitaryMatrix{
         Matrix{
             { std::cos(theta / 2), -std::sin(theta / 2) },
@@ -86,7 +86,7 @@ inline static UnitaryMatrix RY(double theta) {
     };
 }
 
-inline static UnitaryMatrix RZ(double theta) {
+inline UnitaryMatrix RZ(double theta) {
     return UnitaryMatrix{
         Matrix{
             { std::cos(theta / 2) - 1i * std::sin(theta / 2),                                              0 },
@@ -96,14 +96,14 @@ inline static UnitaryMatrix RZ(double theta) {
     };
 }
 
-inline static auto X90 = RX(PI / 2);
-inline static auto Y90 = RY(PI / 2);
-inline static auto Z90 = RZ(PI / 2);
-inline static auto MX90 = RX(-PI / 2);
-inline static auto MY90 = RY(-PI / 2);
-inline static auto MZ90 = RZ(-PI / 2);
+static auto X90 = RX(PI / 2);
+static auto Y90 = RY(PI / 2);
+static auto Z90 = RZ(PI / 2);
+static auto MX90 = RX(-PI / 2);
+static auto MY90 = RY(-PI / 2);
+static auto MZ90 = RZ(-PI / 2);
 
-inline static UnitaryMatrix H{
+static UnitaryMatrix H{
     Matrix{
         { 1 / SQRT_2,  1 / SQRT_2 },
         { 1 / SQRT_2, -1 / SQRT_2 }
@@ -111,7 +111,7 @@ inline static UnitaryMatrix H{
     false
 };
 
-inline static UnitaryMatrix CNOT{
+static UnitaryMatrix CNOT{
     Matrix{
         { 1, 0, 0, 0 },
         { 0, 1, 0, 0 },
@@ -121,7 +121,7 @@ inline static UnitaryMatrix CNOT{
     false
 };
 
-inline static UnitaryMatrix SWAP{
+static UnitaryMatrix SWAP{
     Matrix{
         { 1, 0, 0, 0 },
         { 0, 0, 1, 0 },
@@ -131,7 +131,7 @@ inline static UnitaryMatrix SWAP{
     false
 };
 
-inline static UnitaryMatrix CZ{
+static UnitaryMatrix CZ{
     Matrix{
         { 1, 0, 0,  0 },
         { 0, 1, 0,  0 },
@@ -141,7 +141,7 @@ inline static UnitaryMatrix CZ{
     false
 };
 
-inline static UnitaryMatrix CR(double theta) {
+inline UnitaryMatrix CR(double theta) {
     return UnitaryMatrix{
         Matrix{
             { 1, 0, 0,                                      0 },
@@ -153,7 +153,7 @@ inline static UnitaryMatrix CR(double theta) {
     };
 }
 
-inline static UnitaryMatrix TOFFOLI{
+static UnitaryMatrix TOFFOLI{
     Matrix{
         { 1, 0, 0, 0, 0, 0, 0, 0 },
         { 0, 1, 0, 0, 0, 0, 0, 0 },
@@ -170,7 +170,7 @@ inline static UnitaryMatrix TOFFOLI{
 using GateName = std::string;
 using UnitaryMatrixGenerator = std::function<gates::UnitaryMatrix(CqasmV3xParameter)>;
 
-inline static std::unordered_map<GateName, UnitaryMatrixGenerator> default_gates = {
+static std::unordered_map<GateName, UnitaryMatrixGenerator> default_gates = {
     { "CNOT", [](const auto&) { return gates::CNOT; } },
     { "CR", [](const auto& parameter) { return gates::CR(parameter->as_const_float()->value); } },
     { "CRk", [](const auto& parameter) {

--- a/include/qx/gates.hpp
+++ b/include/qx/gates.hpp
@@ -20,127 +20,140 @@ using namespace std::complex_literals;  // i
 inline constexpr long double PI = std::numbers::pi_v<long double>;
 inline constexpr double SQRT_2 = std::numbers::sqrt2_v<long double>;
 
-static UnitaryMatrix IDENTITY = UnitaryMatrix::identity(2);
+inline static UnitaryMatrix IDENTITY = UnitaryMatrix::identity(2);
 
-static UnitaryMatrix X{
+inline static UnitaryMatrix X{
     Matrix{
         { 0, 1 },
         { 1, 0 }
-    }
+    },
+    false
 };
 
-static UnitaryMatrix Y{
+inline static UnitaryMatrix Y{
     Matrix{
         {  0, -1i },
         { 1i,   0 }
-    }
+    },
+    false
 };
 
-static UnitaryMatrix Z{
+inline static UnitaryMatrix Z{
     Matrix{
         { 1,  0 },
         { 0, -1 }
-    }
+    },
+    false
 };
 
-static UnitaryMatrix S{
+inline static UnitaryMatrix S{
     Matrix{
         { 1,  0 },
         { 0, 1i }
-    }
+    },
+    false
 };
 
-static UnitaryMatrix SDAG = S.dagger();
+inline static UnitaryMatrix SDAG = S.dagger();
 
-static UnitaryMatrix T{
+inline static UnitaryMatrix T{
     Matrix{
         { 1,                        0 },
         { 0, 1 / SQRT_2 + 1i / SQRT_2 }
-    }
+    },
+    false
 };
 
-static UnitaryMatrix TDAG = T.dagger();
+inline static UnitaryMatrix TDAG = T.dagger();
 
-static UnitaryMatrix RX(double theta) {
+inline static UnitaryMatrix RX(double theta) {
     return UnitaryMatrix{
         Matrix{
             {       std::cos(theta / 2), -1i * std::sin(theta / 2) },
             { -1i * std::sin(theta / 2),       std::cos(theta / 2) }
-        }
+        },
+        false
     };
 }
 
-static UnitaryMatrix RY(double theta) {
+inline static UnitaryMatrix RY(double theta) {
     return UnitaryMatrix{
         Matrix{
             { std::cos(theta / 2), -std::sin(theta / 2) },
             { std::sin(theta / 2),  std::cos(theta / 2) }
-        }
+        },
+        false
     };
 }
 
-static UnitaryMatrix RZ(double theta) {
+inline static UnitaryMatrix RZ(double theta) {
     return UnitaryMatrix{
         Matrix{
             { std::cos(theta / 2) - 1i * std::sin(theta / 2),                                              0 },
             {                                              0, std::cos(theta / 2) + 1i * std::sin(theta / 2) }
-        }
+        },
+        false
     };
 }
 
-static auto X90 = RX(PI / 2);
-static auto Y90 = RY(PI / 2);
-static auto Z90 = RZ(PI / 2);
-static auto MX90 = RX(-PI / 2);
-static auto MY90 = RY(-PI / 2);
-static auto MZ90 = RZ(-PI / 2);
+inline static auto X90 = RX(PI / 2);
+inline static auto Y90 = RY(PI / 2);
+inline static auto Z90 = RZ(PI / 2);
+inline static auto MX90 = RX(-PI / 2);
+inline static auto MY90 = RY(-PI / 2);
+inline static auto MZ90 = RZ(-PI / 2);
 
-static UnitaryMatrix H{
+inline static UnitaryMatrix H{
     Matrix{
         { 1 / SQRT_2,  1 / SQRT_2 },
         { 1 / SQRT_2, -1 / SQRT_2 }
-    }
+    },
+    false
 };
 
-static UnitaryMatrix CNOT{
+inline static UnitaryMatrix CNOT{
     Matrix{
         { 1, 0, 0, 0 },
         { 0, 1, 0, 0 },
         { 0, 0, 0, 1 },
         { 0, 0, 1, 0 }
-    }
+    },
+    false
 };
 
-static UnitaryMatrix SWAP{
+inline static UnitaryMatrix SWAP{
     Matrix{
         { 1, 0, 0, 0 },
         { 0, 0, 1, 0 },
         { 0, 1, 0, 0 },
         { 0, 0, 0, 1 }
-    }
+    },
+    false
 };
 
-static UnitaryMatrix CZ{
+inline static UnitaryMatrix CZ{
     Matrix{
         { 1, 0, 0,  0 },
         { 0, 1, 0,  0 },
         { 0, 0, 1,  0 },
         { 0, 0, 0, -1 }
-    }
+    },
+    false
 };
 
-[[maybe_unused]] static UnitaryMatrix CR(double theta) {
+inline static UnitaryMatrix CR(double theta) {
     return UnitaryMatrix{
         Matrix{
             { 1, 0, 0,                                      0 },
             { 0, 1, 0,                                      0 },
             { 0, 0, 1,                                      0 },
             { 0, 0, 0, std::cos(theta) + 1i * std::sin(theta) }
-        }
+        },
+        false
     };
 }
 
-static UnitaryMatrix TOFFOLI{
+inline static UnitaryMatrix TOFFOLI{
     Matrix{
         { 1, 0, 0, 0, 0, 0, 0, 0 },
         { 0, 1, 0, 0, 0, 0, 0, 0 },
@@ -150,13 +163,14 @@ static UnitaryMatrix TOFFOLI{
         { 0, 0, 0, 0, 0, 1, 0, 0 },
         { 0, 0, 0, 0, 0, 0, 0, 1 },
         { 0, 0, 0, 0, 0, 0, 1, 0 }
-    }
+    },
+    false
 };
 
 using GateName = std::string;
 using UnitaryMatrixGenerator = std::function<gates::UnitaryMatrix(CqasmV3xParameter)>;
 
-static std::unordered_map<GateName, UnitaryMatrixGenerator> default_gates = {
+inline static std::unordered_map<GateName, UnitaryMatrixGenerator> default_gates = {
     { "CNOT", [](const auto&) { return gates::CNOT; } },
     { "CR", [](const auto& parameter) { return gates::CR(parameter->as_const_float()->value); } },
     { "CRk", [](const auto& parameter) {

--- a/src/qx/dense_unitary_matrix.cpp
+++ b/src/qx/dense_unitary_matrix.cpp
@@ -2,15 +2,28 @@
 
 namespace qx::core {
 
-DenseUnitaryMatrix::DenseUnitaryMatrix(const Matrix& m)
-: DenseUnitaryMatrix{ m, true } {}
+DenseUnitaryMatrix::DenseUnitaryMatrix(const Matrix& matrix, bool is_unitary_check)
+: matrix_{ matrix }
+, N{ matrix.size() } {
+    if (is_unitary_check) {
+        check_is_unitary();
+    }
+}
+
+DenseUnitaryMatrix::DenseUnitaryMatrix(Matrix&& matrix, bool is_unitary_check)
+: matrix_{ matrix }
+, N{ matrix.size() } {
+    if (is_unitary_check) {
+        check_is_unitary();
+    }
+}
 
 [[nodiscard]] std::complex<double>& DenseUnitaryMatrix::at(std::size_t i, std::size_t j) {
-    return matrix.at(i).at(j);
+    return matrix_.at(i).at(j);
 }
 
 [[nodiscard]] const std::complex<double>& DenseUnitaryMatrix::at(std::size_t i, std::size_t j) const {
-    return matrix.at(i).at(j);
+    return matrix_.at(i).at(j);
 }
 
 bool DenseUnitaryMatrix::operator==(const DenseUnitaryMatrix& other) const {
@@ -19,7 +32,7 @@ bool DenseUnitaryMatrix::operator==(const DenseUnitaryMatrix& other) const {
     }
     for (std::size_t i = 0; i < N; ++i) {
         for (std::size_t j = 0; j < N; ++j) {
-            if (not is_null(matrix[i][j] - other.matrix[i][j])) {
+            if (not is_null(matrix_[i][j] - other.matrix_[i][j])) {
                 return false;
             }
         }
@@ -31,36 +44,36 @@ DenseUnitaryMatrix DenseUnitaryMatrix::operator*(const DenseUnitaryMatrix& other
     if (N != other.N) {
         throw std::runtime_error{ "cannot multiply matrices" };
     }
-    Matrix m(N, Row(N));
+    Matrix matrix(N, Row(N));
     for (std::size_t i = 0; i < N; ++i) {
         for (std::size_t j = 0; j < N; ++j) {
-            m[i][j] = 0;
+            matrix[i][j] = 0;
             for (std::size_t k = 0; k < N; ++k) {
-                m[i][j] += matrix[i][k] * other.matrix[k][j];
+                matrix[i][j] += matrix_[i][k] * other.matrix_[k][j];
             }
         }
     }
-    return DenseUnitaryMatrix{ m, false };
+    return DenseUnitaryMatrix{ std::move(matrix), false };
 }
 
 /* static */ DenseUnitaryMatrix DenseUnitaryMatrix::identity(size_t M) {
-    Matrix m(M, Row(M));
+    Matrix matrix(M, Row(M));
     for (std::size_t i = 0; i < M; ++i) {
         for (std::size_t j = 0; j < M; ++j) {
-            m[i][j] = (i == j) ? 1 : 0;
+            matrix[i][j] = (i == j) ? 1 : 0;
         }
     }
-    return DenseUnitaryMatrix{ m, false };
+    return DenseUnitaryMatrix{ std::move(matrix), false };
 }
 
 DenseUnitaryMatrix DenseUnitaryMatrix::dagger() const {
-    Matrix m(N, Row(N));
+    Matrix matrix(N, Row(N));
     for (std::size_t i = 0; i < N; ++i) {
         for (std::size_t j = 0; j < N; ++j) {
-            m[i][j] = std::conj(matrix[j][i]);
+            matrix[i][j] = std::conj(matrix_[j][i]);
         }
     }
-    return DenseUnitaryMatrix{ m, false };
+    return DenseUnitaryMatrix{ std::move(matrix), false };
 }
 
 DenseUnitaryMatrix DenseUnitaryMatrix::inverse() const {
@@ -95,18 +108,10 @@ DenseUnitaryMatrix DenseUnitaryMatrix::control() const {
     std::size_t last_index = N * 2;
     for (std::size_t i = first_index; i < last_index; ++i) {
         for (std::size_t j = first_index; j < last_index; ++j) {
-            ret.at(i, j) = matrix[i - first_index][j - first_index];
+            ret.at(i, j) = matrix_[i - first_index][j - first_index];
         }
     }
     return ret;
-}
-
-DenseUnitaryMatrix::DenseUnitaryMatrix(const Matrix& m, bool is_unitary_check)
-: matrix{ m }
-, N{ m.size() } {
-    if (is_unitary_check) {
-        check_is_unitary();
-    }
 }
 
 void DenseUnitaryMatrix::check_is_unitary() const {
@@ -120,7 +125,7 @@ void DenseUnitaryMatrix::check_is_square() const {
     if (N == 0) {
         throw std::runtime_error{ "matrix is empty" };
     }
-    if (!std::all_of(matrix.begin(), matrix.end(), [this](const auto& row) { return row.size() == N; })) {
+    if (!std::all_of(matrix_.begin(), matrix_.end(), [this](const auto& row) { return row.size() == N; })) {
         throw std::runtime_error{ "matrix is not square" };
     }
 }

--- a/test/dense_unitary_matrix.cpp
+++ b/test/dense_unitary_matrix.cpp
@@ -16,27 +16,27 @@ using namespace std::complex_literals;
 
 TEST(dense_unitary_matrix_test, reject_non_unitary_matrices) {
     Matrix empty_matrix{};
-    EXPECT_THAT([&empty_matrix]() { DenseUnitaryMatrix test{ empty_matrix }; },
+    EXPECT_THAT([&empty_matrix]() { DenseUnitaryMatrix test{ std::move(empty_matrix) }; },
         ::testing::ThrowsMessage<std::runtime_error>("matrix is empty"));
 
     Matrix non_square_matrix{
         { 1, 0 }
     };
-    EXPECT_THAT([&non_square_matrix]() { DenseUnitaryMatrix test{ non_square_matrix }; },
+    EXPECT_THAT([&non_square_matrix]() { DenseUnitaryMatrix test{ std::move(non_square_matrix) }; },
         ::testing::ThrowsMessage<std::runtime_error>("matrix is not square"));
 
     Matrix non_unitary_1{
         { 1,   0 },
         { 0, 1.1 }
     };
-    EXPECT_THAT([&non_unitary_1]() { DenseUnitaryMatrix test{ non_unitary_1 }; },
+    EXPECT_THAT([&non_unitary_1]() { DenseUnitaryMatrix test{ std::move(non_unitary_1) }; },
         ::testing::ThrowsMessage<std::runtime_error>("matrix is not unitary"));
 
     Matrix non_unitary_2{
         { 0, 0 },
         { 0, 1 }
     };
-    EXPECT_THAT([&non_unitary_2]() { DenseUnitaryMatrix test{ non_unitary_2 }; },
+    EXPECT_THAT([&non_unitary_2]() { DenseUnitaryMatrix test{ std::move(non_unitary_2) }; },
         ::testing::ThrowsMessage<std::runtime_error>("matrix is not unitary"));
 
     Matrix non_unitary_3{
@@ -44,7 +44,7 @@ TEST(dense_unitary_matrix_test, reject_non_unitary_matrices) {
         {  0, 1i, 1i },
         {  0,  1,  0 }
     };
-    EXPECT_THAT([&non_unitary_3]() { DenseUnitaryMatrix test{ non_unitary_3 }; },
+    EXPECT_THAT([&non_unitary_3]() { DenseUnitaryMatrix test{ std::move(non_unitary_3) }; },
         ::testing::ThrowsMessage<std::runtime_error>("matrix is not unitary"));
 }
 
@@ -60,15 +60,19 @@ TEST(dense_unitary_matrix_test, identity) {
 }
 
 TEST(dense_unitary_matrix_test, dagger) {
-    DenseUnitaryMatrix m{ Matrix{
-        {  1 / std::numbers::sqrt2,   1 / std::numbers::sqrt2 },
-        { 1i / std::numbers::sqrt2, -1i / std::numbers::sqrt2 }
-    }};
-    DenseUnitaryMatrix m_dag{ Matrix{
-        { 1 / std::numbers::sqrt2, -1i / std::numbers::sqrt2 },
-        { 1 / std::numbers::sqrt2,  1i / std::numbers::sqrt2 }
-    }};
-    EXPECT_EQ(m.dagger(), m_dag);
+    DenseUnitaryMatrix matrix{
+        Matrix{
+            {  1 / gates::SQRT_2,   1 / gates::SQRT_2 },
+            { 1i / gates::SQRT_2, -1i / gates::SQRT_2 }
+        }
+    };
+    DenseUnitaryMatrix matrix_dagger{
+        Matrix{
+            { 1 / gates::SQRT_2, -1i / gates::SQRT_2 },
+            { 1 / gates::SQRT_2,  1i / gates::SQRT_2 }
+        }
+    };
+    EXPECT_EQ(matrix.dagger(), matrix_dagger);
 }
 
 TEST(dense_unitary_matrix_test, inverse) {


### PR DESCRIPTION
Allow move constructing a `DenseUnitaryMatrix`.
Change `DenseUnitaryMatrix` constructor to receive a unitary check flag.
Add default constructors and assignment operators for `DenseUnitaryMatrix`.
Change all default gate definitions to inline.
Do not check if a matrix is unitary for default gates.