### PR TITLE
[CQT-305] Check if `shots_done` can be removed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Documentation: GitHub Actions `doc` workflow.
 
+### Changed
+- Change SimulationIterationAccumulator to keep `shots_done` and receive `shots_requested` in `get_simulation_result()`.
+
 
 ## [ 0.7.4 ] - [ 2025-01-29 ]
 

--- a/include/qx/simulation_result.hpp
+++ b/include/qx/simulation_result.hpp
@@ -107,7 +107,7 @@ public:
     void add(const SimulationIterationContext& context);
     void append_measurement(const core::MeasurementRegister& measurement);
     void append_bit_measurement(const core::BitMeasurementRegister& bit_measurement);
-    SimulationResult get_simulation_result();
+    SimulationResult get_simulation_result(std::size_t shots_requested);
 
 private:
     template <typename F>
@@ -119,8 +119,7 @@ private:
     std::map<state_string_t, count_t> measurements;
     std::map<state_string_t, count_t> bit_measurements;
 
-    std::uint64_t measurements_count = 0;
-    std::uint64_t bit_measurements_count = 0;
+    std::uint64_t shots_done = 0;
 };
 
 }  // namespace qx

--- a/python/qxelarator/__init__.py
+++ b/python/qxelarator/__init__.py
@@ -16,10 +16,10 @@ class SimulationResult:
         """! Default constructs a SimulationResult."""
 
         ## @var int shots_requested
-        # Always equal to the number of iterations.
+        # Number of iterations the simulation was requested to be performed.
         self.shots_requested = 0
         ## @var int shots_done
-        # Always equal to the number of iterations.
+        # Number of iterations the simulation was actually performed.
         self.shots_done = 0
         ## @var dict results
         # Contains the number of times a given measurement value is captured when running the iterations.

--- a/src/qx/simulation_result.cpp
+++ b/src/qx/simulation_result.cpp
@@ -86,29 +86,31 @@ SimulationIterationContext::SimulationIterationContext()
 
 void SimulationIterationAccumulator::add(const SimulationIterationContext& context) {
     state = context.state;
+    // Notice that the simulator always stores the values of the measurement registers
+    // even when no measure instruction has been executed
+    // When a measure instruction is executed, the effect of collapsing the quantum state is simulated
     append_measurement(context.measurement_register);
     append_bit_measurement(context.bit_measurement_register);
+    shots_done++;
 }
 
 void SimulationIterationAccumulator::append_measurement(const core::MeasurementRegister& measurement) {
     assert(measurements.size() < (static_cast<size_t>(1) << state.get_number_of_qubits()));
     auto measured_state_string{ core::to_substring(measurement, state.get_number_of_qubits()) };
     measurements[measured_state_string]++;
-    measurements_count++;
 }
 
 void SimulationIterationAccumulator::append_bit_measurement(const core::BitMeasurementRegister& bit_measurement) {
     assert(bit_measurements.size() < (static_cast<size_t>(1) << state.get_number_of_qubits()));
     auto bit_measured_state_string{ fmt::format("{}", bit_measurement) };
     bit_measurements[bit_measured_state_string]++;
-    bit_measurements_count++;
 }
 
-SimulationResult SimulationIterationAccumulator::get_simulation_result() {
-    assert(measurements_count > 0);
+SimulationResult SimulationIterationAccumulator::get_simulation_result(std::size_t shots_requested) {
+    assert(shots_done > 0);
 
-    SimulationResult simulation_result{ measurements_count,
-        measurements_count,
+    SimulationResult simulation_result{ shots_done,
+        shots_requested,
         RegisterManager::get_instance().get_qubit_register(),
         RegisterManager::get_instance().get_bit_register() };
 

--- a/src/qx/simulation_result.cpp
+++ b/src/qx/simulation_result.cpp
@@ -107,7 +107,7 @@ void SimulationIterationAccumulator::append_bit_measurement(const core::BitMeasu
 }
 
 // Notice that, with the current implementation:
-// - Either the number of requested shots is equal the number of done shots,
+// - Either the number of requested shots is equal the number of done shots.
 // - Or a simulation error has occurred.
 SimulationResult SimulationIterationAccumulator::get_simulation_result(std::size_t shots_requested) {
     assert(shots_done > 0);

--- a/src/qx/simulation_result.cpp
+++ b/src/qx/simulation_result.cpp
@@ -106,6 +106,9 @@ void SimulationIterationAccumulator::append_bit_measurement(const core::BitMeasu
     bit_measurements[bit_measured_state_string]++;
 }
 
+// Notice that, with the current implementation:
+// - Either the number of requested shots is equal the number of done shots,
+// - Or a simulation error has occurred.
 SimulationResult SimulationIterationAccumulator::get_simulation_result(std::size_t shots_requested) {
     assert(shots_done > 0);
 

--- a/src/qx/simulator.cpp
+++ b/src/qx/simulator.cpp
@@ -71,7 +71,7 @@ std::variant<std::monostate, SimulationResult, SimulationError> execute(
                     acc.add(circuit.execute(std::monostate{}));
                     return acc;
                 });
-        return simulation_iteration_accumulator.get_simulation_result();
+        return simulation_iteration_accumulator.get_simulation_result(iterations);
     } catch (const SimulationError& err) {
         return err;
     }


### PR DESCRIPTION
Update SimulationIterationAccumulator:
- `get_simulation_result` now receives `shots_requested`.
- Add `shots_done`.
- Remove `measurements_count` and `bit_measurements_count`.

Update SimulationResult Python documentation:
- `shots_requested` is the number of requested iterations.
- `shots_done` is the number of performed iterations.