### PR TITLE
[CQT-344] Fix issue #135

### DIFF
--- a/conan/profiles/debug
+++ b/conan/profiles/debug
@@ -5,6 +5,6 @@ compiler.cppstd=23
 build_type=Debug
 
 [options]
-qx/*:asan_enabled=False
+qx/*:asan_enabled=True
 qx/*:build_python=False
 qx/*:cpu_compatibility_mode=False

--- a/conan/profiles/tests-debug
+++ b/conan/profiles/tests-debug
@@ -5,7 +5,7 @@ compiler.cppstd=23
 build_type=Debug
 
 [options]
-qx/*:asan_enabled=False
+qx/*:asan_enabled=True
 qx/*:build_python=False
 qx/*:cpu_compatibility_mode=False
 

--- a/conan/profiles/tests-debug-clang-linux-arm64
+++ b/conan/profiles/tests-debug-clang-linux-arm64
@@ -4,6 +4,9 @@ include(tests-debug)
 compiler=clang
 compiler.version=14
 
+[options]
+qx/*:asan_enabled=False
+
 [conf]
 tools.build:cxxflags=["-stdlib=libc++"]
 tools.build:compiler_executables={ 'c' : 'clang', 'cpp' : 'clang++' }

--- a/conan/profiles/tests-debug-clang-linux-x64
+++ b/conan/profiles/tests-debug-clang-linux-x64
@@ -4,6 +4,9 @@ include(tests-debug)
 compiler=clang
 compiler.version=14
 
+[options]
+qx/*:asan_enabled=False
+
 [conf]
 tools.build:cxxflags=["-stdlib=libc++"]
 tools.build:compiler_executables={ 'c' : 'clang', 'cpp' : 'clang++' }


### PR DESCRIPTION
It seems we can enable address sanitizer for the debug builds except for the `clang` compiler.

We could at least merge these changes, close the issue, and open a new issue focused on fixing the address sanitizer for `clang` builds.

The "good" side of these address sanitizer problems is that:
1. They seem to have to do with gtest, and not with our code.
2. Thy seem to be kind of secondary, i.e., not memory leaks, or misuse of pointers, and so on. For example, for `clang` builds, the address sanitizer complains of memory being allocated with `new` and released with `free`.