### PR TITLE
Disable Windows/Debug job.

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -103,7 +103,9 @@ jobs:
       fail-fast: false
       matrix:
         build_type:
-          - Debug
+          # Disabled temporarily.
+          # Until an antlr4-cppruntime>4.13.1 Conan package builds in Windows/Debug
+          # - Debug
           - Release
     steps:
       - name: Checkout


### PR DESCRIPTION
Disable temporarily.
Until an antlr4-cppruntime>4.13.1 Conan package builds in Windows/Debug.