### PR TITLE
Creating release 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - **Removed** for now removed features.
 
 
-## [ 0.8.0 ] - [ xxxx-yy-zz ]
+## [ 0.8.0 ] - [ 2025-03-21 ]
 
 ### Added
 - Integrate with libqasm 1.1.0 release.

--- a/include/qx/version.hpp
+++ b/include/qx/version.hpp
@@ -1,4 +1,4 @@
 #ifndef QX_VERSION
-#define QX_VERSION "0.7.5"
+#define QX_VERSION "0.8.0"
 #define QX_RELEASE_YEAR "2025"
 #endif


### PR DESCRIPTION
### Added
- Integrate with libqasm 1.1.0 release.
- `pow` gate modifier now works with fractional exponents.