### PR TITLE
[CQT-356] Pi-half rotation gates defined incorrectly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - **Removed** for now removed features.
 
 
+## [ 0.9.0 ] - [ xxxx-yy-zz ]
+
+### Fixed
+- Pi-half rotation gates defined incorrectly.
+
+
 ## [ 0.8.0 ] - [ 2025-03-21 ]
 
 ### Added

--- a/include/qx/gates.hpp
+++ b/include/qx/gates.hpp
@@ -97,12 +97,37 @@ inline UnitaryMatrix RZ(double theta) {
     };
 }
 
-static auto X90 = RX(PI / 2);
-static auto Y90 = RY(PI / 2);
-static auto Z90 = RZ(PI / 2);
-static auto MX90 = RX(-PI / 2);
-static auto MY90 = RY(-PI / 2);
-static auto MZ90 = RZ(-PI / 2);
+static UnitaryMatrix X90{
+    Matrix{
+        { 1/2. + 1i/2., 1/2. - 1i/2. },
+        { 1/2. - 1i/2., 1/2. + 1i/2. }
+    },
+    false
+};
+static UnitaryMatrix MX90{
+    Matrix{
+        { 1/2. - 1i/2., 1/2. + 1i/2. },
+        { 1/2. + 1i/2., 1/2. - 1i/2. }
+    },
+    false
+};
+static UnitaryMatrix Y90{
+    Matrix{
+        { 1/2. + 1i/2., -1/2. - 1i/2. },
+        { 1/2. + 1i/2.,  1/2. + 1i/2. }
+    },
+    false
+};
+static UnitaryMatrix MY90{
+    Matrix{
+        {  1/2. - 1i/2., 1/2. - 1i/2. },
+        { -1/2. + 1i/2., 1/2. - 1i/2. }
+    },
+    false
+};
+static UnitaryMatrix Z90 = S;
+static UnitaryMatrix MZ90 = SDAG;
+
 
 static UnitaryMatrix H{
     Matrix{

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
 if(POLICY CMP0078)
     cmake_policy(SET CMP0078 OLD)
 endif()

--- a/test/dense_unitary_matrix.cpp
+++ b/test/dense_unitary_matrix.cpp
@@ -82,7 +82,7 @@ TEST(dense_unitary_matrix_test, inverse) {
     EXPECT_EQ(gates::RX(PI/4).inverse(), gates::RX(-PI/4));
     EXPECT_EQ(gates::S.inverse(), gates::SDAG);
     EXPECT_EQ(gates::T.inverse(), gates::TDAG);
-    EXPECT_EQ(gates::X90.inverse(), gates::RX(-PI/2));
+    EXPECT_EQ(gates::X90.inverse(), gates::MX90);
 }
 
 TEST(dense_unitary_matrix_test, power_integer) {

--- a/test/integration_test.cpp
+++ b/test/integration_test.cpp
@@ -584,7 +584,7 @@ H q[1]
             { "00",
              core::Complex{ .real = (1. + gates::SQRT_2) / 4, .imag = -0.25, .norm = (2. + gates::SQRT_2) / 8 }      },
             { "01",
-             core::Complex{ .real = (-1. + gates::SQRT_2) / 4, .imag = -0.25, .norm = (2. - gates::SQRT_2) / 8 }     },
+             core::Complex{ .real = (-1. + gates::SQRT_2) / 4, .imag = 0.25, .norm = (2. - gates::SQRT_2) / 8 }      },
             { "10", core::Complex{ .real = (1. + gates::SQRT_2) / 4, .imag = 0.25, .norm = (2. + gates::SQRT_2) / 8 } },
             { "11",
              core::Complex{

--- a/test/integration_test.cpp
+++ b/test/integration_test.cpp
@@ -550,8 +550,8 @@ H q[1]
     // Expected 'q' state should be |00>+|01>+|11>
     EXPECT_EQ(actual.state,
         (SimulationResult::State{
-            { "00", core::Complex{ .real = 1. / gates::SQRT_2, .imag = 0, .norm = 0.5 } },
-            { "10", core::Complex{ .real = gates::SQRT_2 / 4, .imag = gates::SQRT_2 / 4, .norm = 0.25 } },
+            { "00",                  core::Complex{ .real = 1. / gates::SQRT_2, .imag = 0, .norm = 0.5 } },
+            { "10",  core::Complex{ .real = gates::SQRT_2 / 4, .imag = gates::SQRT_2 / 4, .norm = 0.25 } },
             { "11", core::Complex{ .real = gates::SQRT_2 / 4, .imag = -gates::SQRT_2 / 4, .norm = 0.25 } }
     }));
 }
@@ -581,10 +581,14 @@ H q[1]
     // Expected 'q' state should be |00>+|01>+|10>+|11>
     EXPECT_EQ(actual.state,
         (SimulationResult::State{
-            { "00", core::Complex{ .real = (1. + gates::SQRT_2) / 4, .imag = -0.25, .norm = (2. + gates::SQRT_2) / 8 } },
-            { "01", core::Complex{ .real = (-1. + gates::SQRT_2) / 4, .imag = -0.25, .norm = (2. - gates::SQRT_2) / 8 } },
+            { "00",
+             core::Complex{ .real = (1. + gates::SQRT_2) / 4, .imag = -0.25, .norm = (2. + gates::SQRT_2) / 8 }      },
+            { "01",
+             core::Complex{ .real = (-1. + gates::SQRT_2) / 4, .imag = -0.25, .norm = (2. - gates::SQRT_2) / 8 }     },
             { "10", core::Complex{ .real = (1. + gates::SQRT_2) / 4, .imag = 0.25, .norm = (2. + gates::SQRT_2) / 8 } },
-            { "11", core::Complex{ .real = (-1. + gates::SQRT_2) / 4, .imag = -0.25, .norm = (2. - gates::SQRT_2) / 8 } }
+            { "11",
+             core::Complex{
+             .real = (-1. + gates::SQRT_2) / 4, .imag = -0.25, .norm = (2. - gates::SQRT_2) / 8 }                    }
     }));
 }
 

--- a/test/integration_test.cpp
+++ b/test/integration_test.cpp
@@ -538,16 +538,8 @@ H q[1]
 )";
     std::size_t iterations = 1;
     auto actual = run_from_string(program, iterations, "3.0");
-    for (const auto& superposed_state : actual.state) {
-        fmt::print("\t{1}  {2:.{0}f} + {3:.{0}f}i  (norm = {4:.{0}f})\n",
-            config::OUTPUT_DECIMALS,
-            superposed_state.value,
-            superposed_state.amplitude.real,
-            superposed_state.amplitude.imag,
-            superposed_state.amplitude.norm);
-    }
 
-    // Expected 'q' state should be |00>+|01>+|11>
+    // Expected 'q' state should be |00>+|10>+|11>
     EXPECT_EQ(actual.state,
         (SimulationResult::State{
             { "00",                  core::Complex{ .real = 1. / gates::SQRT_2, .imag = 0, .norm = 0.5 } },
@@ -569,14 +561,6 @@ H q[1]
 )";
     std::size_t iterations = 1;
     auto actual = run_from_string(program, iterations, "3.0");
-    for (const auto& superposed_state : actual.state) {
-        fmt::print("\t{1}  {2:.{0}f} + {3:.{0}f}i  (norm = {4:.{0}f})\n",
-            config::OUTPUT_DECIMALS,
-            superposed_state.value,
-            superposed_state.amplitude.real,
-            superposed_state.amplitude.imag,
-            superposed_state.amplitude.norm);
-    }
 
     // Expected 'q' state should be |00>+|01>+|10>+|11>
     EXPECT_EQ(actual.state,

--- a/test/integration_test.cpp
+++ b/test/integration_test.cpp
@@ -525,6 +525,69 @@ ctrl.X q[0], q[1]
     }));
 }
 
+TEST_F(IntegrationTest, control_gate_modifier__ctrl_x90) {
+    auto program = R"(
+version 3.0
+
+qubit[2] q
+
+H q[0]
+ctrl.X90 q[0], q[1]
+H q[0]
+H q[1]
+)";
+    std::size_t iterations = 1;
+    auto actual = run_from_string(program, iterations, "3.0");
+    for (const auto& superposed_state : actual.state) {
+        fmt::print("\t{1}  {2:.{0}f} + {3:.{0}f}i  (norm = {4:.{0}f})\n",
+            config::OUTPUT_DECIMALS,
+            superposed_state.value,
+            superposed_state.amplitude.real,
+            superposed_state.amplitude.imag,
+            superposed_state.amplitude.norm);
+    }
+
+    // Expected 'q' state should be |00>+|01>+|11>
+    EXPECT_EQ(actual.state,
+        (SimulationResult::State{
+            { "00", core::Complex{ .real = 1. / gates::SQRT_2, .imag = 0, .norm = 0.5 } },
+            { "10", core::Complex{ .real = gates::SQRT_2 / 4, .imag = gates::SQRT_2 / 4, .norm = 0.25 } },
+            { "11", core::Complex{ .real = gates::SQRT_2 / 4, .imag = -gates::SQRT_2 / 4, .norm = 0.25 } }
+    }));
+}
+
+TEST_F(IntegrationTest, control_gate_modifier__ctrl_rx_half_pi) {
+    auto program = R"(
+version 3.0
+
+qubit[2] q
+
+H q[0]
+ctrl.Rx(pi/2) q[0], q[1]
+H q[0]
+H q[1]
+)";
+    std::size_t iterations = 1;
+    auto actual = run_from_string(program, iterations, "3.0");
+    for (const auto& superposed_state : actual.state) {
+        fmt::print("\t{1}  {2:.{0}f} + {3:.{0}f}i  (norm = {4:.{0}f})\n",
+            config::OUTPUT_DECIMALS,
+            superposed_state.value,
+            superposed_state.amplitude.real,
+            superposed_state.amplitude.imag,
+            superposed_state.amplitude.norm);
+    }
+
+    // Expected 'q' state should be |00>+|01>+|10>+|11>
+    EXPECT_EQ(actual.state,
+        (SimulationResult::State{
+            { "00", core::Complex{ .real = (1. + gates::SQRT_2) / 4, .imag = -0.25, .norm = (2. + gates::SQRT_2) / 8 } },
+            { "01", core::Complex{ .real = (-1. + gates::SQRT_2) / 4, .imag = -0.25, .norm = (2. - gates::SQRT_2) / 8 } },
+            { "10", core::Complex{ .real = (1. + gates::SQRT_2) / 4, .imag = 0.25, .norm = (2. + gates::SQRT_2) / 8 } },
+            { "11", core::Complex{ .real = (-1. + gates::SQRT_2) / 4, .imag = -0.25, .norm = (2. - gates::SQRT_2) / 8 } }
+    }));
+}
+
 TEST_F(IntegrationTest, gate_modifier__ctrl_pow_2_s) {
     auto program = R"(
 version 3.0


### PR DESCRIPTION
Update definition of gates X90, Y90, Z90, MX90, MY90, and MZ90.
Add control_gate_modifier__ctrl_x90 and control_gate_modifier__ctrl_rx_half_pi integration tests.