### PR TITLE
[CQT-360] QX simulator outputs invalid states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 - Pi-half rotation gates defined incorrectly.
+- Bug in SparseComplex::operator=, which was not always performing the assignment.
 
 
 ## [ 0.8.0 ] - [ 2025-03-21 ]
@@ -122,7 +123,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Meaningful error message when parsing or simulation fails.
 
 ### Fixed
-- Does not crash when too many qubits asked.
+- QX does not crash when too many qubits asked.
 
 
 ## [ 0.6.3 ] - [ 2023-09-19 ]

--- a/include/qx/quantum_state.hpp
+++ b/include/qx/quantum_state.hpp
@@ -36,6 +36,12 @@ public:
     QuantumState(std::size_t qubit_register_size, std::size_t bit_register_size);
     QuantumState(std::size_t qubit_register_size, std::size_t bit_register_size,
         std::initializer_list<PairBasisVectorStringComplex> values);
+    QuantumState(const QuantumState& other) = default;
+    QuantumState(QuantumState&& other) noexcept = default;
+    QuantumState& operator=(const QuantumState& other) = default;
+    QuantumState& operator=(QuantumState&& other) noexcept = default;
+    ~QuantumState() = default;
+
     [[nodiscard]] std::size_t get_number_of_qubits() const;
     [[nodiscard]] std::size_t get_number_of_bits() const;
     [[nodiscard]] bool is_normalized();

--- a/include/qx/quantum_state.hpp
+++ b/include/qx/quantum_state.hpp
@@ -36,11 +36,6 @@ public:
     QuantumState(std::size_t qubit_register_size, std::size_t bit_register_size);
     QuantumState(std::size_t qubit_register_size, std::size_t bit_register_size,
         std::initializer_list<PairBasisVectorStringComplex> values);
-    QuantumState(const QuantumState& other) = default;
-    QuantumState(QuantumState&& other) noexcept = default;
-    QuantumState& operator=(const QuantumState& other) = default;
-    QuantumState& operator=(QuantumState&& other) noexcept = default;
-    ~QuantumState() = default;
 
     [[nodiscard]] std::size_t get_number_of_qubits() const;
     [[nodiscard]] std::size_t get_number_of_bits() const;

--- a/include/qx/simulation_result.hpp
+++ b/include/qx/simulation_result.hpp
@@ -84,6 +84,8 @@ public:
     Measurements bit_measurements;
 };
 
+std::ostream& operator<<(std::ostream& os, const Measurement& measurement);
+std::ostream& operator<<(std::ostream& os, const SuperposedState& superposed_state);
 std::ostream& operator<<(std::ostream& os, const SimulationResult& result);
 
 //----------------------------//
@@ -124,5 +126,9 @@ private:
 
 }  // namespace qx
 
+template <>
+struct fmt::formatter<qx::Measurement> : fmt::ostream_formatter {};
+template <>
+struct fmt::formatter<qx::SuperposedState> : fmt::ostream_formatter {};
 template <>
 struct fmt::formatter<qx::SimulationResult> : fmt::ostream_formatter {};

--- a/include/qx/sparse_array.hpp
+++ b/include/qx/sparse_array.hpp
@@ -47,13 +47,17 @@ public:
     SparseArray() = delete;
     explicit SparseArray(std::size_t s);
     SparseArray(std::size_t s, std::initializer_list<PairBasisVectorStringComplex> values);
+    SparseArray(const SparseArray& other) = default;
+    SparseArray(SparseArray&& other) noexcept = default;
+    SparseArray& operator=(const SparseArray& other);
+    SparseArray& operator=(SparseArray&& other) noexcept = default;
+    ~SparseArray() = default;
 
     [[nodiscard]] ConstIterator begin() const;
     [[nodiscard]] ConstIterator end() const;
     [[nodiscard]] Iterator begin();
     [[nodiscard]] Iterator end();
 
-    SparseArray& operator=(MapBasisVectorToSparseComplex map);
     SparseArray& operator*=(double d);
     SparseComplex& operator[](const BasisVector& index);
 

--- a/include/qx/sparse_array.hpp
+++ b/include/qx/sparse_array.hpp
@@ -28,10 +28,6 @@ struct SparseComplex {
 
     SparseComplex() = default;
     explicit SparseComplex(std::complex<double> c);
-    SparseComplex(const SparseComplex& other);
-    SparseComplex(SparseComplex&& other) noexcept;
-    SparseComplex& operator=(const SparseComplex& other);
-    SparseComplex& operator=(SparseComplex&& other) noexcept;
 };
 using SparseElement = std::pair<BasisVector, SparseComplex>;
 bool compare_sparse_elements(const SparseElement& lhs, const SparseElement& rhs);
@@ -47,11 +43,6 @@ public:
     SparseArray() = delete;
     explicit SparseArray(std::size_t s);
     SparseArray(std::size_t s, std::initializer_list<PairBasisVectorStringComplex> values);
-    SparseArray(const SparseArray& other) = default;
-    SparseArray(SparseArray&& other) noexcept = default;
-    SparseArray& operator=(const SparseArray& other);
-    SparseArray& operator=(SparseArray&& other) noexcept = default;
-    ~SparseArray() = default;
 
     [[nodiscard]] ConstIterator begin() const;
     [[nodiscard]] ConstIterator end() const;

--- a/src/qx/simulation_result.cpp
+++ b/src/qx/simulation_result.cpp
@@ -1,6 +1,7 @@
 #include "qx/simulation_result.hpp"
 
 #include <fmt/core.h>
+#include <fmt/ranges.h>
 
 #include <cstdint>  // uint8_t
 #include <ostream>
@@ -34,37 +35,27 @@ std::uint8_t SimulationResult::get_bit_measurement(
     return static_cast<std::uint8_t>(state_string[state_string.size() - index - 1] - '0');
 }
 
+std::ostream& operator<<(std::ostream& os, const Measurement& measurement) {
+    return os << (measurement.state.empty()
+                   ? std::string{}
+                   : fmt::format("state='{}', count='{}'", measurement.state, measurement.count));
+}
+
+std::ostream& operator<<(std::ostream& os, const SuperposedState& superposed_state) {
+    return os << fmt::format("value='{1}', amplitude='{2:.{0}f} + {3:.{0}f}i', norm='{4:.{0}f}'",
+               config::OUTPUT_DECIMALS,
+               superposed_state.value,
+               superposed_state.amplitude.real,
+               superposed_state.amplitude.imag,
+               superposed_state.amplitude.norm);
+}
+
 std::ostream& operator<<(std::ostream& os, const SimulationResult& simulation_result) {
-    fmt::print(os, "State:\n");
-    for (const auto& superposed_state : simulation_result.state) {
-        fmt::print(os,
-            "\t{1}  {2:.{0}f} + {3:.{0}f}i  (norm = {4:.{0}f})\n",
-            config::OUTPUT_DECIMALS,
-            superposed_state.value,
-            superposed_state.amplitude.real,
-            superposed_state.amplitude.imag,
-            superposed_state.amplitude.norm);
-    }
-    fmt::print(os, "Measurements:\n");
-    for (const auto& measurement : simulation_result.measurements) {
-        fmt::print(os,
-            "\t{1}  {2}/{3}  (count/shots % = {4:.{0}f})\n",
-            config::OUTPUT_DECIMALS,
-            measurement.state,
-            measurement.count,
-            simulation_result.shots_done,
-            static_cast<double>(measurement.count) / static_cast<double>(simulation_result.shots_done));
-    }
-    fmt::print(os, "Bit measurements:\n");
-    for (const auto& bit_measurement : simulation_result.bit_measurements) {
-        fmt::print(os,
-            "\t{1}  {2}/{3}  (count/shots % = {4:.{0}f})\n",
-            config::OUTPUT_DECIMALS,
-            bit_measurement.state,
-            bit_measurement.count,
-            simulation_result.shots_done,
-            static_cast<double>(bit_measurement.count) / static_cast<double>(simulation_result.shots_done));
-    }
+    fmt::print(os, "Shots requested: {}\n", simulation_result.shots_requested);
+    fmt::print(os, "Shots done: {}\n", simulation_result.shots_done);
+    fmt::print(os, "State:\n\t{}\n", fmt::join(simulation_result.state, "\n\t"));
+    fmt::print(os, "Measurements:\n\t{}\n", fmt::join(simulation_result.measurements, "\n\t"));
+    fmt::print(os, "Bit measurements:\n\t{}\n", fmt::join(simulation_result.bit_measurements, "\n\t"));
     fmt::print(os, "Qubit register:\n\t{}\n", simulation_result.qubit_register);
     fmt::print(os, "Bit register:\n\t{}", simulation_result.bit_register);
     return os;

--- a/src/qx/sparse_array.cpp
+++ b/src/qx/sparse_array.cpp
@@ -21,7 +21,7 @@ SparseComplex::SparseComplex(const SparseComplex& other) {
 }
 
 SparseComplex::SparseComplex(SparseComplex&& other) noexcept {
-    value = other.value;
+    value = std::move(other.value);
 }
 
 SparseComplex& SparseComplex::operator=(const SparseComplex& other) {
@@ -56,8 +56,12 @@ SparseArray::SparseArray(std::size_t s, std::initializer_list<PairBasisVectorStr
     }
 }
 
-SparseArray& SparseArray::operator=(MapBasisVectorToSparseComplex map) {
-    data_ = std::move(map);
+SparseArray& SparseArray::operator=(const SparseArray& other) {
+    size_ = other.size_;
+    zero_counter_ = other.zero_counter_;
+    // data_ = other.data_ seems not to erase previous elements of data_, thus we force data_.clear()
+    data_.clear();
+    data_ = other.data_;
     return *this;
 }
 

--- a/src/qx/sparse_array.cpp
+++ b/src/qx/sparse_array.cpp
@@ -16,28 +16,6 @@ SparseComplex::SparseComplex(std::complex<double> c) {
     value = c;
 }
 
-SparseComplex::SparseComplex(const SparseComplex& other) {
-    value = other.value;
-}
-
-SparseComplex::SparseComplex(SparseComplex&& other) noexcept {
-    value = std::move(other.value);
-}
-
-SparseComplex& SparseComplex::operator=(const SparseComplex& other) {
-    if (std::abs(other.value) >= config::EPSILON) {
-        value = other.value;
-    }
-    return *this;
-}
-
-SparseComplex& SparseComplex::operator=(SparseComplex&& other) noexcept {
-    if (std::abs(other.value) >= config::EPSILON) {
-        value = other.value;
-    }
-    return *this;
-}
-
 bool compare_sparse_elements(const SparseElement& lhs, const SparseElement& rhs) {
     return lhs.first < rhs.first;
 }
@@ -54,15 +32,6 @@ SparseArray::SparseArray(std::size_t s, std::initializer_list<PairBasisVectorStr
         }
         data_[BasisVector{ basis_vector_string }] = SparseComplex{ complex_value };
     }
-}
-
-SparseArray& SparseArray::operator=(const SparseArray& other) {
-    size_ = other.size_;
-    zero_counter_ = other.zero_counter_;
-    // data_ = other.data_ seems not to erase previous elements of data_, thus we force data_.clear()
-    data_.clear();
-    data_ = other.data_;
-    return *this;
 }
 
 SparseArray& SparseArray::operator*=(double d) {

--- a/test/integration_test.cpp
+++ b/test/integration_test.cpp
@@ -548,6 +548,28 @@ H q[1]
     }));
 }
 
+TEST_F(IntegrationTest, control_gate_modifier__ctrl_x90_after_h_q1) {
+    auto program = R"(
+version 3.0
+
+qubit[2] q
+
+H q[1]
+ctrl.X90 q[0], q[1]
+H q[0]
+H q[1]
+)";
+    std::size_t iterations = 1;
+    auto actual = run_from_string(program, iterations, "3.0");
+
+    // Expected 'q' state should be |00>+|01>
+    EXPECT_EQ(actual.state,
+        (SimulationResult::State{
+            { "00", core::Complex{ .real = 1. / gates::SQRT_2, .imag = 0, .norm = 0.5 } },
+            { "01", core::Complex{ .real = 1. / gates::SQRT_2, .imag = 0, .norm = 0.5 } }
+    }));
+}
+
 TEST_F(IntegrationTest, control_gate_modifier__ctrl_rx_half_pi) {
     auto program = R"(
 version 3.0


### PR DESCRIPTION
The problem came from `SparseComplex::operator=`, which was not always performing the assignment (only when a check was true, and that check was wrong).

Implement `operator<<` for `qx::Measurement` and `qx::SuperposedState`.
Add `fmt::formatter`s for `qx::Measurement` and `qx::SuperposedState`.

Remove rule of 5 for SparseComplex.
Remove `SparseArray::operator=(MapBasisVectorToSparseComplex)`.