### PR TITLE
[CQT-391] Add Rn gate to QX.

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -24,7 +24,7 @@ CheckOptions:
   - key: readability-identifier-naming.FunctionCase
     value: lower_case
   - key: readability-identifier-naming.FunctionIgnoredRegexp
-    value: "CR|RX|RY|RZ"
+    value: "CR|RX|RY|RZ|RN"
   - key: readability-identifier-naming.MemberCase
     value: lower_case
   - key: readability-identifier-naming.MemberIgnoredRegexp

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - **Fixed** for any bug fixes.
 - **Removed** for now removed features.
 
+## [M.m.P] - [ xxxx-yy-zz ]
+
+### Added
+- Rn gate to instruction library
+
 
 ## [ 0.9.0 ] - [ 2025-04-07 ]
 

--- a/include/qx/gates.hpp
+++ b/include/qx/gates.hpp
@@ -97,6 +97,22 @@ inline UnitaryMatrix RZ(double theta) {
     };
 }
 
+inline UnitaryMatrix RN(double nx, double ny, double nz, double theta, double phi) {
+    return UnitaryMatrix{
+        Matrix{
+            { 
+                std::exp(1i * phi) * (std::cos(theta / 2) - 1i * nz * std::sin(theta / 2)),
+                std::exp(1i * phi) * (-ny * std::sin(theta / 2) - 1i * nx * std::sin(theta / 2)) 
+            },
+            { 
+                std::exp(1i * phi) * (ny * std::sin(theta / 2) - 1i * nx * std::sin(theta / 2)),
+                std::exp(1i * phi) * (std::cos(theta / 2) + 1i * nz * std::sin(theta / 2))
+            }
+        },
+        false
+    };
+}
+
 static UnitaryMatrix X90{
     Matrix{
         { 1/2. + 1i/2., 1/2. - 1i/2. },
@@ -210,6 +226,12 @@ static std::unordered_map<GateName, UnitaryMatrixGenerator> default_gates = {
     { "Rx", [](const auto& parameters) { return gates::RX(parameters[0]->as_const_float()->value); } },
     { "Ry", [](const auto& parameters) { return gates::RY(parameters[0]->as_const_float()->value); } },
     { "Rz", [](const auto& parameters) { return gates::RZ(parameters[0]->as_const_float()->value); } },
+    { "Rn", [](const auto& parameters) { return gates::RN(
+        parameters[0]->as_const_float()->value,
+        parameters[1]->as_const_float()->value,
+        parameters[2]->as_const_float()->value,
+        parameters[3]->as_const_float()->value,
+        parameters[4]->as_const_float()->value); } },
     { "S", [](const auto&) { return gates::S; } },
     { "Sdag", [](const auto&) { return gates::SDAG; } },
     { "SWAP", [](const auto&) { return gates::SWAP; } },

--- a/test/integration_test.cpp
+++ b/test/integration_test.cpp
@@ -504,6 +504,24 @@ pow(2).X q
     }));
 }
 
+TEST_F(IntegrationTest, power_gate_modifier__pow_2_rn) {
+    auto program = R"(
+version 3.0
+
+qubit q
+
+pow(2).Rn(0,1,0,pi/2,pi/4) q
+)";
+    std::size_t iterations = 10'000;
+    auto actual = run_from_string(program, iterations);
+
+    // Expected 'q' state should be |0> as pow(2).X is equivalent to I
+    EXPECT_EQ(actual.state,
+        (SimulationResult::State{
+            { "1", core::Complex{ .real = 0, .imag = 1, .norm = 1 } }
+    }));
+}
+
 TEST_F(IntegrationTest, control_gate_modifier__ctrl_x) {
     auto program = R"(
 version 3.0
@@ -595,6 +613,27 @@ H q[1]
             { "11",
              core::Complex{
              .real = (-1. + gates::SQRT_2) / 4, .imag = -0.25, .norm = (2. - gates::SQRT_2) / 8 }                    }
+    }));
+}
+
+TEST_F(IntegrationTest, control_gate_modifier__ctrl_rn) {
+    auto program = R"(
+version 3.0
+
+qubit[2] q
+
+H q[0]
+ctrl.Rn(1,0,0,pi,pi/2) q[0], q[1]
+)";
+    std::size_t iterations = 1;
+    auto actual = run_from_string(program, iterations, "3.0");
+
+    // Expected 'q' state should be |00>+|11> as ctrl.Rn(1,0,0,pi,pi/2) is equivalent to CNOT
+    // State is |00>+|11> after creating the Bell state
+    EXPECT_EQ(actual.state,
+        (SimulationResult::State{
+            { "00", core::Complex{ .real = 1 / gates::SQRT_2, .imag = 0, .norm = 0.5 } },
+            { "11", core::Complex{ .real = 1 / gates::SQRT_2, .imag = 0, .norm = 0.5 } }
     }));
 }
 

--- a/test/qxelarator/test_qxelarator.py
+++ b/test/qxelarator/test_qxelarator.py
@@ -64,6 +64,23 @@ b = measure q
         simulation_result = qxelarator.execute_string(cqasm_string, iterations=20, seed=123)
         self.assertEqual(simulation_result.results, {"0": 12, "1": 8})
 
+    def test_rn_gate(self):
+        cqasm_string = """\
+version 3.0
+
+qubit q
+bit b
+
+Rn(1,0,0,pi,pi/2) q
+b = measure q
+"""
+        simulation_result = qxelarator.execute_string(cqasm_string, iterations=2)
+
+        self.assertIsInstance(simulation_result, qxelarator.SimulationResult)
+        self.assertEqual(simulation_result.shots_requested, 2)
+        self.assertEqual(simulation_result.shots_done, 2)
+        self.assertEqual(simulation_result.results, {"1": 2})
+        self.assertAlmostEqual(simulation_result.state["1"], complex(1., 0.), places=15)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Added:
- `Rn` gate to `gates.hpp`.
- C++ and Python tests.
- `RN` function identifier to ignore as case style in `clang-tidy`.
- entry to Changelog.