### PR TITLE
Creating release 0.10.0

### DIFF
--- a/.github/workflows/assets.yaml
+++ b/.github/workflows/assets.yaml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v4
       - uses: actions/setup-python@v5
       - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==3.0.1
+        run: python -m pip install cibuildwheel==2.23.3
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse
       - uses: actions/upload-artifact@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - **Fixed** for any bug fixes.
 - **Removed** for now removed features.
 
-## [M.m.P] - [ xxxx-yy-zz ]
+## [0.10.0] - [ 2025-08-28 ]
 
 ### Added
-- Rn gate to instruction library
+- Rn gate to instruction library.
 - Support for Python 3.13.
 - Integrate with libqasm 1.2.1 release.
 

--- a/include/qx/version.hpp
+++ b/include/qx/version.hpp
@@ -1,4 +1,4 @@
 #ifndef QX_VERSION
-#define QX_VERSION "0.9.0"
+#define QX_VERSION "0.10.0"
 #define QX_RELEASE_YEAR "2025"
 #endif


### PR DESCRIPTION
### Added
- Rn gate to instruction library.
- Support for Python 3.13.
- Integrate with libqasm 1.2.1 release.